### PR TITLE
feat: upload 컴포넌트 구현

### DIFF
--- a/src/components/commons/Upload/index.jsx
+++ b/src/components/commons/Upload/index.jsx
@@ -1,0 +1,56 @@
+import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+const InputFile = ({ children, name, accept, value, onChange, ...props }) => {
+  const [file, setFile] = useState(value);
+  const inputRef = useRef(null);
+
+  const handleFileChange = e => {
+    const { files } = e.target;
+    const changedFile = files[0];
+    setFile(changedFile);
+    if (onChange) {
+      onChange(changedFile);
+    }
+  };
+
+  const handleChooseFile = () => {
+    inputRef.current.click();
+  };
+
+  return (
+    <div onClick={handleChooseFile} {...props}>
+      <Input
+        type="file"
+        ref={inputRef}
+        name={name}
+        accept={accept}
+        onChange={handleFileChange}
+      />
+      {typeof children === 'function' ? children(file) : children}
+    </div>
+  );
+};
+
+export default InputFile;
+
+InputFile.defaultProps = {
+  children: '',
+  name: '',
+  accept: 0,
+  value: '',
+  onChange: () => {},
+};
+
+InputFile.propTypes = {
+  children: PropTypes.string,
+  name: PropTypes.string,
+  accept: PropTypes.string,
+  value: PropTypes.string,
+  onChange: PropTypes.func,
+};
+
+const Input = styled.input`
+  display: none;
+`;

--- a/src/stories/Upload.stories.jsx
+++ b/src/stories/Upload.stories.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import Upload from '@components/commons/Upload';
+
+export default {
+  title: 'Component/Upload',
+  component: Upload,
+};
+
+export const Default = () => (
+  <Upload>
+    {file => <button type="button">{file ? file.name : 'Click me'}</button>}
+  </Upload>
+);


### PR DESCRIPTION
## 💡 이슈번호

- close: #7 

## 📝 Points

> 리뷰어들이 중점적으로 보았으면 하는 부분을 적습니다.
> (ex: 어려웠던 점, 개선하고자 하는 점, 논의 하고자하는 점)

사진 업로드를 위한 input 컴포넌트는 따로 분리해서 구현했습니다. (type='file' 스타일이 예쁘지 않아요!)
