### PR TITLE
feat: 라우팅 기능 구현, 라이브러리 버전 수정, 헤더 디폴드 라우팅

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -15,6 +15,7 @@ module.exports = {
     config.resolve.alias["@components"] = path.resolve(__dirname, "../src/components");
     config.resolve.alias["@hooks"] = path.resolve(__dirname, "../src/hooks");
     config.resolve.alias["@pages"] = path.resolve(__dirname, "../src/pages");
+    config.resolve.alias['@utils'] = path.resolve(__dirname, "../src/utils");
     return config
   }
 }

--- a/craco.config.js
+++ b/craco.config.js
@@ -9,6 +9,7 @@ module.exports = {
       '@components': path.resolve(__dirname, 'src/components'),
       '@hooks': path.resolve(__dirname, 'src/hooks'),
       '@pages': path.resolve(__dirname, 'src/pages'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
     },
   },
-}
+};

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^6.0.2",
+    "react-router-dom": "5",
     "react-scripts": "4.0.3",
     "web-vitals": "^1.0.1"
   },

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import Header from '@components/domain/Header';
+import { Route, Switch } from 'react-router-dom';
 import {
   ArticleDetailPage,
   ChannelPage,
@@ -22,7 +23,7 @@ import {
 } from '@pages';
 
 const App = () => (
-  <BrowserRouter>
+  <Header>
     <Switch>
       <Route exact path="/">
         <HomePage />
@@ -79,7 +80,7 @@ const App = () => (
         <NotFoundPage />
       </Route>
     </Switch>
-  </BrowserRouter>
+  </Header>
 );
 
 export default App;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import {
   ArticleDetailPage,
   ChannelPage,
@@ -23,26 +23,62 @@ import {
 
 const App = () => (
   <BrowserRouter>
-    <Routes>
-      <Route path="/" element={<HomePage />} />
-      <Route path="/article/:id" element={<ArticleDetailPage />} />
-      <Route path="/channel/:id" element={<ChannelPage />} />
-      <Route path="/edit/article/:id" element={<EditArticlePage />} />
-      <Route path="/edit/my" element={<EditMyInfoPage />} />
-      <Route path="/channel/my" element={<MyChannelPage />} />
-      <Route path="/info/my" element={<MyInfoPage />} />
-      <Route path="/info/purchase" element={<PurchaseHistoryPage />} />
-      <Route path="/purchase" element={<PurchasePage />} />
-      <Route path="/search" element={<SearchPage />} />
-      <Route path="/series/:id" element={<SeriesDetailPage />} />
-      <Route path="/series" element={<SeriesListPage />} />
-      <Route path="/signin" element={<SignInPage />} />
-      <Route path="/signup" element={<SignUpPage />} />
-      <Route path="/article/write" element={<WriteArticlePage />} />
-      <Route path="/writes" element={<WriteListPage />} />
-      <Route path="/series/write" element={<WriteSeriesPage />} />
-      <Route path="*" element={<NotFoundPage />} />
-    </Routes>
+    <Switch>
+      <Route exact path="/">
+        <HomePage />
+      </Route>
+      <Route exact path="/article/:id">
+        <ArticleDetailPage />
+      </Route>
+      <Route exact path="/channel/:id">
+        <ChannelPage />
+      </Route>
+      <Route exact path="/edit/article/:id">
+        <EditArticlePage />
+      </Route>
+      <Route exact path="/edit/my">
+        <EditMyInfoPage />
+      </Route>
+      <Route exact path="/channel/my">
+        <MyChannelPage />
+      </Route>
+      <Route exact path="/info/my">
+        <MyInfoPage />
+      </Route>
+      <Route exact path="/info/purchase">
+        <PurchaseHistoryPage />
+      </Route>
+      <Route exact path="/purchase">
+        <PurchasePage />
+      </Route>
+      <Route exact path="/search">
+        <SearchPage />
+      </Route>
+      <Route exact path="/series/:id">
+        <SeriesDetailPage />
+      </Route>
+      <Route exact path="/series">
+        <SeriesListPage />
+      </Route>
+      <Route exact path="/signin">
+        <SignInPage />
+      </Route>
+      <Route exact path="/signup">
+        <SignUpPage />
+      </Route>
+      <Route exact path="/article/write">
+        <WriteArticlePage />
+      </Route>
+      <Route exact path="/writes">
+        <WriteListPage />
+      </Route>
+      <Route exact path="/series/write">
+        <WriteSeriesPage />
+      </Route>
+      <Route exact path="*">
+        <NotFoundPage />
+      </Route>
+    </Switch>
   </BrowserRouter>
 );
 

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -2,23 +2,25 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { useToggle } from '@hooks';
 import { Button } from '@components';
+import { useHistory } from 'react-router-dom';
 import Input from '../../commons/Input';
 import Nav from './Nav';
 import Logo from './Logo';
 import UserModal from './UserModal';
 
 const Header = () => {
+  const history = useHistory();
   const [state, toggle] = useToggle();
-  const handleClickSearch = () => {
-    console.log('검색페이지로 넘어감');
-  };
+  // const handleClickSearch = () => {
+  //   console.log('검색페이지로 넘어감');
+  // };
   return (
     <StyledHeader>
       <Logo />
       <Nav items={['Home', '연재하기', '내 채널']} />
       <SearchBox>
         <Input name="search" />
-        <span type="button" onClick={handleClickSearch}>
+        <span type="button" onClick={history.push('/search')}>
           검색 아이콘
         </span>
       </SearchBox>

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -2,41 +2,46 @@ import React from 'react';
 import styled from '@emotion/styled';
 import { useToggle } from '@hooks';
 import { Button } from '@components';
-import { useHistory } from 'react-router-dom';
+import { BrowserRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
 import Input from '../../commons/Input';
 import Nav from './Nav';
 import Logo from './Logo';
 import UserModal from './UserModal';
 
-const Header = () => {
-  const history = useHistory();
+const Header = ({ children }) => {
   const [state, toggle] = useToggle();
-  // const handleClickSearch = () => {
-  //   console.log('검색페이지로 넘어감');
-  // };
   return (
-    <StyledHeader>
-      <Logo />
-      <Nav items={['Home', '연재하기', '내 채널']} />
-      <SearchBox>
-        <Input name="search" />
-        <span type="button" onClick={history.push('/search')}>
-          검색 아이콘
-        </span>
-      </SearchBox>
-      <Utils>
-        <Button type="button">글쓰기 버튼</Button>
-        <span type="button" onClick={toggle}>
-          사람 아이콘
-        </span>
-        {/* <a href="/">로그인</a> */}
-      </Utils>
-      <StyledUserModal
-        items={['마이페이지', '관심 시리즈', '로그아웃']}
-        visible={state}
-      />
-    </StyledHeader>
+    <BrowserRouter>
+      <StyledHeader>
+        <Logo />
+        <Nav items={['Home', '연재하기', '내 채널']} />
+        <SearchBox>
+          <Input name="search" />
+          <span type="button">검색 아이콘</span>
+        </SearchBox>
+        <Utils>
+          <Button type="button">글쓰기 버튼</Button>
+          <span type="button" onClick={toggle}>
+            사람 아이콘
+          </span>
+          {/* <a href="/">로그인</a> */}
+        </Utils>
+        <StyledUserModal
+          items={['마이페이지', '관심 시리즈', '로그아웃']}
+          visible={state}
+        />
+      </StyledHeader>
+      {children}
+    </BrowserRouter>
   );
+};
+
+Header.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node,
+  ]).isRequired,
 };
 
 export default Header;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,7 +1283,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.14.0", "@babel/runtime@^7.14.8", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1", "@babel/runtime@^7.4.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.16.3"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.16.3.tgz"
   integrity sha512-WBwekcqacdY2e9AF/Q7WLFUWmdJGJTkbjqTjoMDgXkVZ3ZRUvOPsLb5KdwISoQVsbP+DQzVZW4Zhci0DvpbNTQ==
@@ -7900,6 +7900,18 @@ history@5.0.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 history@^5.1.0:
   version "5.1.0"
   resolved "https://registry.npmjs.org/history/-/history-5.1.0.tgz"
@@ -7916,7 +7928,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -8763,6 +8775,11 @@ is-wsl@^2.1.1, is-wsl@^2.2.0:
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -9767,7 +9784,7 @@ loglevel@^1.6.8:
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz"
   integrity sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -10054,6 +10071,14 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+
+mini-create-react-context@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz#072171561bfdc922da08a60c2197a497cc2d1d5e"
+  integrity sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==
+  dependencies:
+    "@babel/runtime" "^7.12.1"
+    tiny-warning "^1.0.3"
 
 mini-css-extract-plugin@0.11.3:
   version "0.11.3"
@@ -10911,6 +10936,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -12209,7 +12241,7 @@ react-is@17.0.2, "react-is@^16.8.0 || ^17.0.0", react-is@^17.0.1, react-is@^17.0
   resolved "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -12241,13 +12273,42 @@ react-refresh@^0.8.3:
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz"
   integrity sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg==
 
-react-router-dom@^6.0.0, react-router-dom@^6.0.2:
+react-router-dom@5:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.0.tgz#da1bfb535a0e89a712a93b97dd76f47ad1f32363"
+  integrity sha512-ObVBLjUZsphUUMVycibxgMdh5jJ1e3o+KpAZBVeHcNQZ4W+uUGGWsokurzlF4YOldQYRQL4y6yFRWM4m3svmuQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.2.1"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router-dom@^6.0.0:
   version "6.0.2"
   resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.0.2.tgz"
   integrity sha512-cOpJ4B6raFutr0EG8O/M2fEoyQmwvZWomf1c6W2YXBZuFBx8oTk/zqjXghwScyhfrtnt0lANXV2182NQblRxFA==
   dependencies:
     history "^5.1.0"
     react-router "6.0.2"
+
+react-router@5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.2.1.tgz#4d2e4e9d5ae9425091845b8dbc6d9d276239774d"
+  integrity sha512-lIboRiOtDLFdg1VTemMwud9vRVuOCZmUIT/7lUoZiSpPODiiH1UQlfXy+vPLC/7IWdFYnhRwAyNqA/+I7wnvKQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-router@6.0.2, react-router@^6.0.0:
   version "6.0.2"
@@ -12677,6 +12738,11 @@ resolve-from@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@^3.1.2:
   version "3.1.4"
@@ -13918,7 +13984,12 @@ timsort@^0.3.0:
   resolved "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-warning@^1.0.2:
+tiny-invariant@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.2.0.tgz#a1141f86b672a9148c72e978a19a73b9b94a15a9"
+  integrity sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2, tiny-warning@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -14490,6 +14561,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- SPA를 위한 라우팅 기능을 구현했습니다. 페이지 이동시 url이 변경되고 Link를 통해 페이지 이동을 할 수 있습니다. 
- Header 컴포넌트가 라우팅에 상관없이 떠있을 수 있도록 디폴트로 설정했습니다. 
- react-router-dom 버전을 6에서 5로 수정했습니다.

## 📝 Results

> 구현한 결과를 첨부합니다.
![스크린샷 2021-12-02 오전 12 46 27](https://user-images.githubusercontent.com/69751205/144476038-682c60ad-a43e-40bf-ad66-b07f6e6558ea.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.

- Header에 라우팅 기능을 붙여하는데, 코드의 일관성과 가독성을 위해 Header 컴포넌트의 수정이 필요해보여요! 같이 얘기해봅시다!
