### PR TITLE
feat: 시리즈 라우팅

### DIFF
--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -26,13 +26,17 @@ const CardList = ({ list, ...props }) => (
             </div>
             <div className='card-textArea'>
               <div>
-                <div>{ item.writer.nickname }</div>
+                <div className='card-userId'>
+                  <Link to={`/channel/${ item.writer.userId }`}>
+                    {item.writer.nickname}
+                  </Link>
+                </div>
                 <div className='card-likes'>
                   <Icons.Like fontSize='1rem' />
                   { item.series.likes } Likes
                 </div>
               </div>
-              <div className="title">
+              <div className="card-title">
                 <Link to={`/series/${item.series.id}`}>
                   { item.series.title }
                 </Link>
@@ -140,8 +144,14 @@ const Card = styled.div`
       > div:last-child {
         margin-bottom: 0;
       }
+
+      .card-userId {
+        &:hover {
+          text-decoration: underline;
+        }
+      }
       
-      .title {
+      .card-title {
         font-size: 1.125rem;
         color: #000000;
         line-height: 1.5rem;

--- a/src/components/domain/SeriesDetail/index.jsx
+++ b/src/components/domain/SeriesDetail/index.jsx
@@ -9,6 +9,7 @@ import {
   CommentList,
   Image
 } from '@components';
+import { Link } from 'react-router-dom';
 
 const SeriesDetail = ({ detail }) => {
   const commentList = [
@@ -23,15 +24,19 @@ const SeriesDetail = ({ detail }) => {
     <>
       <ViewContainer>
         <div className="imageWrapper">
-          <Image src={detail.series.thumbnail } width='100%' height='100%' />
+          <Image src={ detail.series.thumbnail } width='100%' height='100%' />
         </div>
         <div className="viewArticle">
           <div>
             <div className="viewArticle-title">{ detail.series.title }</div>
             <div className="viewArticle-info">
               <div className="userInfo">
-                <span />
-                <span>{ detail.writer.nickname }</span>
+                <Link to={`/channel/${detail.writer.userId}`}>
+                  <span>
+                    <Image src={ detail.writer.profileImage } width='100%' height='100%' />
+                  </span>
+                  <span>{ detail.writer.nickname }</span>
+                </Link>
               </div>
               <div>
                 <span>{ detail.series.likes }</span> Likes
@@ -41,7 +46,15 @@ const SeriesDetail = ({ detail }) => {
               { detail.series.introduceText }
             </div>
             <div className="viewArticle-edit">
-              <div>수정</div>
+              <Link to={ `/series-update/${ detail.series.id }` }>
+                <Button
+                  width="100%"
+                  height="3.125rem"
+                  font-size="1.5rem"
+                >
+                  수정하기
+                </Button>
+              </Link>
             </div>
           </div>
           <div>
@@ -76,13 +89,15 @@ const SeriesDetail = ({ detail }) => {
                 <div>구독료</div>
                 <div>{ detail.series.price } 원</div>
               </div>
-              <Button
-                width="100%"
-                height="3.125rem"
-                font-size="1.5rem"
-              >
-                결제하기
-              </Button>
+              <Link to='/purchase'>
+                <Button
+                  width="100%"
+                  height="3.125rem"
+                  font-size="1.5rem"
+                >
+                  결제하기
+                </Button>
+              </Link>
             </div>
           </div>
         </div>
@@ -123,13 +138,14 @@ const ViewContainer = styled.div`
     display: flex;
     align-details: center;
 
-    > span:nth-of-type(1) {
+    span:nth-of-type(1) {
       display: inline-block;
       width: 1.875rem;
       height: 1.875rem;
       border-radius: 50%;
       background-color: grey;
       margin-right: 0.3125rem;
+      overflow: hidden;
     }
   }
 


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

리스트
- 작가 닉네임 클릭시 채널 페이지 연결
- 타이틀, 썸네일 클릭시 디테일 페이지로 연결

*스타일 변경 예정 - 지금은 글에 라우팅이 돼있는데, 클릭 영역이 너무 작아서 div전체가 클릭 영역이 되게 바꿀 예정 => 이부분은 스타일 건드릴 떄 한 꺼번에

디테일
- 결제 페이지 연결
- 수정하기 페이지 연결 => /series/update/${ series.id }
- 작가 프로필&닉네임 클릭시 채널 페이지 연결

남은 거
- 카테고리 클릭시 해당 카테고리로 정렬 결과 보여주기위한 라우팅

## 📝 Results

> 구현한 결과를 첨부합니다.

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
