### PR TITLE
feat: 글 작성 리스트 페이지 마크업, 더미데이터, 링크 작업

### DIFF
--- a/src/components/commons/Input/index.jsx
+++ b/src/components/commons/Input/index.jsx
@@ -41,7 +41,6 @@ Input.defaultProps = {
   title: '',
   value: '',
   onChange: () => {},
-  value: '',
   name: '',
 };
 

--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -3,75 +3,63 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import convertCategory from '@utils/convertCategory';
-import { Icons, Image } from '@components'
+import { Icons, Image } from '@components';
 
 const CardList = ({ list, ...props }) => (
-    <CardContainer {...props}>
-      {
-        list.map(( item ) =>
-          <Card key={ item.series.id }>
-            {
-              item.subscribe.status === 'SUBSCRIPTION_AVAILABLE' ?
-                <SubscribeStatusDiv>
-                  <div className='available'>모집중</div>
-                </SubscribeStatusDiv> :
-                <SubscribeStatusDiv>
-                <div className='unAvailable'>연재중</div>
-              </SubscribeStatusDiv>
-            }
-            <div className='card-imageArea'>
-              <Link to={`/series/${ item.series.id }`}>
-                <Image src={ item.series.thumbnail } width='100%' height='100%' />
+  <CardContainer {...props}>
+    {list.map(item => (
+      <Card key={item.series.id}>
+        {item.subscribe.status === 'SUBSCRIPTION_AVAILABLE' ? (
+          <SubscribeStatusDiv>
+            <div className="available">모집중</div>
+          </SubscribeStatusDiv>
+        ) : (
+          <SubscribeStatusDiv>
+            <div className="unAvailable">연재중</div>
+          </SubscribeStatusDiv>
+        )}
+        <div className="card-imageArea">
+          <Link to={`/series/${item.series.id}`}>
+            <Image src={item.series.thumbnail} width="100%" height="100%" />
+          </Link>
+        </div>
+        <div className="card-textArea">
+          <div>
+            <div className="card-userId">
+              <Link to={`/channel/${item.writer.userId}`}>
+                {item.writer.nickname}
               </Link>
             </div>
-            <div className='card-textArea'>
-              <div>
-                <div className='card-userId'>
-                  <Link to={`/channel/${ item.writer.userId }`}>
-                    {item.writer.nickname}
-                  </Link>
-                </div>
-                <div className='card-likes'>
-                  <Icons.Like fontSize='1rem' />
-                  { item.series.likes } Likes
-                </div>
-              </div>
-              <div className="card-title">
-                <Link to={`/series/${item.series.id}`}>
-                  { item.series.title }
-                </Link>
-              </div>
-              <div>
-                { item.series.introduceSentence }
-              </div>
-              <div>
-                <div className='category'>
-                  {
-                    convertCategory(item.category)
-                  }
-                </div>
-                <div>
-                  {
-                    item.subscribe.status === 'SUBSCRIPTION_AVAILABLE' ?
-                      `모집마감 ~ ${ item.subscribe.endDate }` :
-                      `연재종료 ~ ${ item.series.endDate }`
-                  }
-                </div>
-              </div>
+            <div className="card-likes">
+              <Icons.Like fontSize="1rem" />
+              {item.series.likes} Likes
             </div>
-          </Card>
-        )
-      }
-    </CardContainer>
-  );
+          </div>
+          <div className="card-title">
+            <Link to={`/series/${item.series.id}`}>{item.series.title}</Link>
+          </div>
+          <div>{item.series.introduceSentence}</div>
+          <div>
+            <div className="category">{convertCategory(item.category)}</div>
+            <div>
+              {item.subscribe.status === 'SUBSCRIPTION_AVAILABLE'
+                ? `모집마감 ~ ${item.subscribe.endDate}`
+                : `연재종료 ~ ${item.series.endDate}`}
+            </div>
+          </div>
+        </div>
+      </Card>
+    ))}
+  </CardContainer>
+);
 
 CardList.defaultProps = {
   list: [],
-}
+};
 
 CardList.propTypes = {
   list: PropTypes.array,
-}
+};
 
 export default CardList;
 
@@ -79,7 +67,7 @@ const CardContainer = styled.div`
   width: 100%;
   height: auto;
   display: flex;
-  flex-flow : row wrap;
+  flex-flow: row wrap;
 `;
 
 /* 
@@ -94,17 +82,19 @@ const CardContainer = styled.div`
 const margin = '1.875rem';
 const contentsMaxCount = 4;
 const Card = styled.div`
-  width: calc((100% - (${ margin } * ${ contentsMaxCount - 1 })) / ${ contentsMaxCount });
-  margin-right: ${ margin };
+  width: calc(
+    (100% - (${margin} * ${contentsMaxCount - 1})) / ${contentsMaxCount}
+  );
+  margin-right: ${margin};
   margin-bottom: 2.5rem;
   display: flex;
   flex-direction: column;
   position: relative;
 
-  &:nth-of-type(${ contentsMaxCount }n) {
+  &:nth-of-type(${contentsMaxCount}n) {
     margin-right: 0;
   }
-  
+
   .card {
     &-imageArea {
       height: 11rem;
@@ -133,14 +123,14 @@ const Card = styled.div`
         align-items: center;
         border: 0.0625rem solid #ffb15c;
       }
-      
+
       > div {
         margin-bottom: 0.875rem;
         display: flex;
         justify-content: space-between;
         align-items: center;
       }
-      
+
       > div:last-child {
         margin-bottom: 0;
       }
@@ -150,13 +140,13 @@ const Card = styled.div`
           text-decoration: underline;
         }
       }
-      
+
       .card-title {
         font-size: 1.125rem;
         color: #000000;
         line-height: 1.5rem;
         flex-grow: 1;
-  
+
         &:hover {
           text-decoration: underline;
         }
@@ -169,7 +159,7 @@ const SubscribeStatusDiv = styled.div`
   position: absolute;
   top: 0;
   right: -0.625rem;
-  
+
   > * {
     padding: 0.625rem;
   }

--- a/src/pages/WriteListPage/index.jsx
+++ b/src/pages/WriteListPage/index.jsx
@@ -1,5 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Wrapper, CardList } from '@components';
+import styled from '@emotion/styled';
+import { getSeries } from '@apis/series';
+import { Link } from 'react-router-dom';
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 
-const WriteListPage = () => <div />;
+const WriteListPage = () => {
+  const [series, setSeries] = useState([]);
+
+  const getInitialData = async () => {
+    const response = await getSeries({ url: '/series' });
+    setSeries(response.data);
+  };
+
+  useEffect(() => {
+    getInitialData();
+  }, []);
+  return (
+    <Wrapper>
+      <Container>
+        <Span>
+          <H1>연재중인 시리즈</H1>
+          <StyeldAddCircleOutlineIcon />
+          <Link to="series-write">새 시리즈 작성하기</Link>
+        </Span>
+        <CardList list={series} />
+      </Container>
+    </Wrapper>
+  );
+};
 
 export default WriteListPage;
+
+const H1 = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+  margin-right: 1rem;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  margin-top: 5rem;
+`;
+
+const Span = styled.span`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const StyeldAddCircleOutlineIcon = styled(AddCircleOutlineIcon)`
+  color: #4b4b4b;
+`;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

헤더에 연재하기 버튼을 눌렀을 때 이동하는 `글을 쓸 수 있는 시리즈 + 시리즈를 생성` 기능을 맡고 있는 WriteListPage를 구현했습니다.
api는 회의 때 빼먹은 내용이라, 다시 노티해야할 것 같아 우선은 전체 시리즈를 불러오는 api response를 더미데이터로 사용하고 있습니다.
아티클 작성을 위한 라우팅은 추후 api 후 연결 할 예정이고, 시리즈 작성에 대한 라우팅 작업은 했습니다.

## 📝 Results

> 구현한 결과를 첨부합니다.

![스크린샷 2021-12-08 오후 4 06 59](https://user-images.githubusercontent.com/69751205/145164461-86f13527-6cb8-4fcd-9902-164e0ea12c39.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
