### PR TITLE
feat: 아티클 작성 페이지 생성 기능 구현, UploadImage컴포넌트 구현

### DIFF
--- a/src/components/commons/Input/index.jsx
+++ b/src/components/commons/Input/index.jsx
@@ -41,7 +41,6 @@ Input.defaultProps = {
   title: '',
   value: '',
   onChange: () => {},
-  value: '',
   name: '',
 };
 

--- a/src/components/commons/Upload/index.jsx
+++ b/src/components/commons/Upload/index.jsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 
@@ -12,12 +12,14 @@ const InputFile = ({
   isFile,
   ...props
 }) => {
+  const [file, setFile] = useState(value);
   const inputRef = useRef(null);
 
   const handleFileChange = e => {
     const { files } = e.target;
     const changedFile = files[0];
     if (onChange) {
+      setFile(changedFile);
       onChange(changedFile);
     }
   };
@@ -36,7 +38,7 @@ const InputFile = ({
         onChange={handleFileChange}
         disabled={disabled && disabled}
       />
-      {children}
+      {typeof children === 'function' ? children(file) : children}
     </div>
   );
 };
@@ -52,7 +54,7 @@ InputFile.defaultProps = {
 };
 
 InputFile.propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   name: PropTypes.string,
   accept: PropTypes.string,
   value: PropTypes.string,

--- a/src/components/domain/ArticleEditor/index.jsx
+++ b/src/components/domain/ArticleEditor/index.jsx
@@ -17,6 +17,7 @@ const ArticleEditor = ({ value, onChange, disabled, ...props }) => {
         onChange={handleInputChange}
         disabled={disabled && disabled}
         placeholder="제목"
+        maxlength="300"
       />
       <StyledTextArea
         width="100%"
@@ -26,6 +27,7 @@ const ArticleEditor = ({ value, onChange, disabled, ...props }) => {
         onInput={handleInputChange}
         disabled={disabled && disabled}
         placeholder="내용"
+        maxlength="5000"
       />
     </StyledSection>
   );

--- a/src/components/domain/EditArticleForm/ArticleEditor.jsx
+++ b/src/components/domain/EditArticleForm/ArticleEditor.jsx
@@ -13,7 +13,7 @@ const ArticleEditor = ({ value, onChange, disabled, ...props }) => {
         width="100%"
         height="2rem"
         name="title"
-        // value={value.title}
+        value={value.title}
         onChange={handleInputChange}
         disabled={disabled && disabled}
         placeholder="제목"
@@ -23,7 +23,7 @@ const ArticleEditor = ({ value, onChange, disabled, ...props }) => {
         width="100%"
         height="100%"
         name="content"
-        // value={value.introduceSentence}
+        value={value.content}
         onInput={handleInputChange}
         disabled={disabled && disabled}
         placeholder="내용"

--- a/src/components/domain/EditArticleForm/index.jsx
+++ b/src/components/domain/EditArticleForm/index.jsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import { ConfirmCancleButtons, Upload, Image } from '@components';
+import { useForm } from '@hooks';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import ArticleEditor from './ArticleEditor';
+
+const EditArticleForm = ({ onSubmit }) => {
+  const [file, setFile] = useState({});
+  const {
+    values,
+    // errors,
+    // setValues,
+    handleChange,
+    handleSubmit,
+  } = useForm({
+    initialValues: {
+      title: '',
+      content: '',
+    },
+    onSubmit: async data => {
+      function jsonBlob(obj) {
+        return new Blob([JSON.stringify(obj)], {
+          type: 'application/json',
+        });
+      }
+
+      const formData = new FormData();
+      formData.append('thumbnail', file);
+      formData.append('request', jsonBlob(data));
+
+      onSubmit && (await onSubmit(formData));
+    },
+    validate: ({ values }) => {
+      const newErrors = {};
+      if (!values.title) newErrors.title = '제목을 입력해주세요.';
+      if (!values.content) newErrors.content = '내용을 입력해주세요.';
+      return newErrors;
+    },
+  });
+
+  const handleChangefile = file => {
+    file && setFile(file);
+  };
+
+  console.log(values, file);
+
+  return (
+    <Form onSubmit={handleSubmit}>
+      <ArticleEditor onChange={handleChange} value={values} />
+      <div>
+        <UploadImage src="" alt="thumbnail" />
+        <Upload name="thumbnail" onChange={handleChangefile}>
+          {file => (
+            <div>
+              <button type="button">{file ? file.name : 'Click me'}</button>
+              <span>{file ? file.name : ''}</span>
+            </div>
+          )}
+        </Upload>
+      </div>
+      <Buttons confirmName="제출" />
+    </Form>
+  );
+};
+
+EditArticleForm.defaultProps = {
+  onSubmit: () => {},
+};
+
+EditArticleForm.propTypes = {
+  onSubmit: PropTypes.func,
+};
+
+export default EditArticleForm;
+
+const Form = styled.form`
+  width: 80%;
+  margin: 0 auto;
+`;
+
+const Buttons = styled(ConfirmCancleButtons)`
+  margin-top: 2rem;
+`;
+
+const UploadImage = styled(Image)`
+  width: 10rem;
+  height: 10rem;
+`;

--- a/src/components/domain/EditArticleForm/index.jsx
+++ b/src/components/domain/EditArticleForm/index.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { ConfirmCancleButtons, Upload, Image } from '@components';
+import { ConfirmCancleButtons, ImageUpload } from '@components';
 import { useForm } from '@hooks';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
@@ -9,7 +9,7 @@ const EditArticleForm = ({ onSubmit }) => {
   const [file, setFile] = useState({});
   const {
     values,
-    // errors,
+    errors,
     // setValues,
     handleChange,
     handleSubmit,
@@ -19,6 +19,8 @@ const EditArticleForm = ({ onSubmit }) => {
       content: '',
     },
     onSubmit: async data => {
+      console.log(values, file);
+
       function jsonBlob(obj) {
         return new Blob([JSON.stringify(obj)], {
           type: 'application/json',
@@ -31,7 +33,7 @@ const EditArticleForm = ({ onSubmit }) => {
 
       onSubmit && (await onSubmit(formData));
     },
-    validate: ({ values }) => {
+    validate: values => {
       const newErrors = {};
       if (!values.title) newErrors.title = '제목을 입력해주세요.';
       if (!values.content) newErrors.content = '내용을 입력해주세요.';
@@ -43,22 +45,13 @@ const EditArticleForm = ({ onSubmit }) => {
     file && setFile(file);
   };
 
-  console.log(values, file);
-
   return (
     <Form onSubmit={handleSubmit}>
-      <ArticleEditor onChange={handleChange} value={values} />
-      <div>
-        <UploadImage src="" alt="thumbnail" />
-        <Upload name="thumbnail" onChange={handleChangefile}>
-          {file => (
-            <div>
-              <button type="button">{file ? file.name : 'Click me'}</button>
-              <span>{file ? file.name : ''}</span>
-            </div>
-          )}
-        </Upload>
-      </div>
+      <Title>아티클 작성 </Title>
+      <StyledArticleEditor onChange={handleChange} value={values} />
+      <ErrorMessage>{errors.title || errors.content}</ErrorMessage>
+      <Title>썸네일 선택</Title>
+      <ImageUpload onChange={handleChangefile} valuename="thumbnail" />
       <Buttons confirmName="제출" />
     </Form>
   );
@@ -79,11 +72,19 @@ const Form = styled.form`
   margin: 0 auto;
 `;
 
+const StyledArticleEditor = styled(ArticleEditor)``;
+
 const Buttons = styled(ConfirmCancleButtons)`
   margin-top: 2rem;
 `;
 
-const UploadImage = styled(Image)`
-  width: 10rem;
-  height: 10rem;
+const Title = styled.h4`
+  margin-bottom: 1rem;
+  font-weight: 700;
+`;
+
+const ErrorMessage = styled.span`
+  display: block;
+  height: 3rem;
+  color: #ffb15c;
 `;

--- a/src/components/domain/ImageUpload/index.jsx
+++ b/src/components/domain/ImageUpload/index.jsx
@@ -1,1 +1,69 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import { Upload, Image } from '@components';
 
+const ImageUpload = ({ onChange, name }) => {
+  const [imageUrl, setImageUrl] = useState('');
+  const [file, setFile] = useState({});
+
+  const handleChangefile = file => {
+    setFile(file);
+    onChange && onChange(file);
+
+    const fileReader = new FileReader();
+    fileReader.readAsDataURL(file);
+    fileReader.onload = () => {
+      setImageUrl(fileReader.result);
+    };
+  };
+
+  return (
+    <div>
+      <UploadImage src={imageUrl} alt={name} />
+      <StyledUpload name={name} onChange={handleChangefile}>
+        <button type="button">File Select</button>
+      </StyledUpload>
+      <span>{file ? file.name : ''}</span>
+    </div>
+  );
+};
+
+ImageUpload.defaultProps = {
+  onChange: () => {},
+  name: '',
+};
+
+ImageUpload.propTypes = {
+  onChange: PropTypes.func,
+  name: PropTypes.string,
+};
+
+export default ImageUpload;
+
+const UploadImage = styled(Image)`
+  width: 10rem;
+  height: 10rem;
+`;
+
+const StyledUpload = styled(Upload)`
+  display: flex;
+  align-items: center;
+  button {
+    width: 6.25rem;
+    padding: 0.3rem;
+    cursor: pointer;
+    user-select: none;
+    border-radius: 50px;
+    border: none;
+    margin-right: 0.5rem;
+    color: ${({ isFile }) => (isFile ? '#ffb15c' : '#4b4b4b')};
+    box-shadow: 0 0.25rem 0.375rem rgba(50, 50, 93, 0.11),
+      0 0.063rem 0.188rem rgba(0, 0, 0, 0.08);
+    background-color: #fff;
+    text-align: center;
+    &:hover {
+      color: #ffb15c;
+    }
+  }
+`;

--- a/src/components/domain/ImageUpload/index.jsx
+++ b/src/components/domain/ImageUpload/index.jsx
@@ -1,16 +1,12 @@
 import React, { useState } from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
-import { Upload, Image } from '@components';
+import { Upload } from '@components';
 
-const ImageUpload = ({ onChange, name }) => {
+const ImageUpload = ({ onChange, valuename, buttonName, circle }) => {
   const [imageUrl, setImageUrl] = useState('');
-  const [file, setFile] = useState({});
 
-  const handleChangefile = file => {
-    setFile(file);
-    onChange && onChange(file);
-
+  const getImageUrl = file => {
     const fileReader = new FileReader();
     fileReader.readAsDataURL(file);
     fileReader.onload = () => {
@@ -18,37 +14,45 @@ const ImageUpload = ({ onChange, name }) => {
     };
   };
 
+  const handleChangefile = file => {
+    onChange && onChange(file);
+    file ? getImageUrl(file) : setImageUrl('');
+  };
+
   return (
-    <div>
-      <UploadImage src={imageUrl} alt={name} />
-      <StyledUpload name={name} onChange={handleChangefile}>
-        <button type="button">File Select</button>
+    <Wrapper>
+      <UploadImage imageUrl={imageUrl} circle={circle} />
+      <StyledUpload valuename={valuename} onChange={handleChangefile}>
+        <button type="button">{buttonName}</button>
       </StyledUpload>
-      <span>{file ? file.name : ''}</span>
-    </div>
+    </Wrapper>
   );
 };
 
 ImageUpload.defaultProps = {
   onChange: () => {},
-  name: '',
+  valuename: '',
+  circle: false,
+  buttonName: 'File Select',
 };
 
 ImageUpload.propTypes = {
   onChange: PropTypes.func,
-  name: PropTypes.string,
+  valuename: PropTypes.string,
+  circle: PropTypes.bool,
+  buttonName: PropTypes.string,
 };
 
 export default ImageUpload;
 
-const UploadImage = styled(Image)`
+const Wrapper = styled.div`
   width: 10rem;
-  height: 10rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 `;
 
 const StyledUpload = styled(Upload)`
-  display: flex;
-  align-items: center;
   button {
     width: 6.25rem;
     padding: 0.3rem;
@@ -56,7 +60,6 @@ const StyledUpload = styled(Upload)`
     user-select: none;
     border-radius: 50px;
     border: none;
-    margin-right: 0.5rem;
     color: ${({ isFile }) => (isFile ? '#ffb15c' : '#4b4b4b')};
     box-shadow: 0 0.25rem 0.375rem rgba(50, 50, 93, 0.11),
       0 0.063rem 0.188rem rgba(0, 0, 0, 0.08);
@@ -66,4 +69,16 @@ const StyledUpload = styled(Upload)`
       color: #ffb15c;
     }
   }
+`;
+
+const UploadImage = styled.div`
+  width: 100%;
+  height: 10rem;
+  background-image: url(${({ imageUrl }) => imageUrl});
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  border-radius: ${({ circle }) => (circle ? '100px' : '4px')};
+  background-color: #949494;
+  margin-bottom: 0.8rem;
 `;

--- a/src/components/domain/SeriesEditor/index.jsx
+++ b/src/components/domain/SeriesEditor/index.jsx
@@ -17,6 +17,7 @@ const SeriesEditor = ({ value, onChange, disabled, ...props }) => {
         onInput={handleInputChange}
         disabled={disabled && disabled}
         placeholder="제목"
+        maxlength="300"
       />
       <StyledTextArea
         width="100%"
@@ -26,6 +27,7 @@ const SeriesEditor = ({ value, onChange, disabled, ...props }) => {
         onInput={handleInputChange}
         disabled={disabled && disabled}
         placeholder="소개"
+        maxlength="300"
       />
       <StyledTextArea
         width="100%"
@@ -35,6 +37,7 @@ const SeriesEditor = ({ value, onChange, disabled, ...props }) => {
         onInput={handleInputChange}
         disabled={disabled && disabled}
         placeholder="설명"
+        maxlength="5000"
       />
     </StyledSection>
   );

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -25,4 +25,5 @@ export { default as SeriesEditor } from './domain/SeriesEditor';
 export { default as EditMyInfoForm } from './domain/EditMyInfoForm';
 export { default as SignUpForm } from './domain/SignUpForm';
 export { default as ConfirmCancleButtons } from './domain/ConfirmCancleButtons';
-export { default as ArticleEditor } from './domain/ArticleEditor';
+export { default as EditArticleForm } from './domain/EditArticleForm';
+export { default as ImageUpload } from './domain/ImageUpload';

--- a/src/pages/WriteArticlePage/index.jsx
+++ b/src/pages/WriteArticlePage/index.jsx
@@ -1,30 +1,9 @@
 import React from 'react';
-import {
-  Wrapper,
-  ConfirmCancleButtons,
-  ArticleEditor,
-  Upload,
-} from '@components';
-import styled from '@emotion/styled';
+import { Wrapper, EditArticleForm } from '@components';
 
 const WriteArticlePage = () => (
   <Wrapper>
-    <Form>
-      <ArticleEditor />
-      <Upload>
-        <button type="button">Click me</button>
-      </Upload>
-      <Buttons confirmName="제출" />
-    </Form>
+    <EditArticleForm />
   </Wrapper>
 );
 export default WriteArticlePage;
-
-const Form = styled.form`
-  width: 80%;
-  margin: 0 auto;
-`;
-
-const Buttons = styled(ConfirmCancleButtons)`
-  margin-top: 2rem;
-`;


### PR DESCRIPTION
## 📝 Tasks

- 아티클 작성 페이지 생성 기능 구현
- UploadImage컴포넌트 구현

## 📝 Results

![image](https://user-images.githubusercontent.com/81611808/145166834-157ceefb-efbb-4d27-add9-1065aba1c77d.png)
![image](https://user-images.githubusercontent.com/81611808/145166881-765fa180-76b8-4bbb-a946-8a2e083acc9d.png)

**UploadImage props**
- onChange : input 값(파일)이 바뀔 때 실행할 로직
- valuename : input 값의 이름 (카멜케이스 쓰니 오류 나서 이렇게 쓰라고 하더라고요)
- buttonName : 업로드 버튼 이름
- circle: 이미지 모양. ture면 원, false면 사각형

*고정된 이미지 사이즈와 비율를 유지하기 위해 image컴포넌트가 아닌 background-image를 사용하였습니다

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
