### PR TITLE
feat: 시리즈/아티클 작성 페이지 마크업, 임시 api 연동, 기능

### DIFF
--- a/src/pages/WriteListPage/index.jsx
+++ b/src/pages/WriteListPage/index.jsx
@@ -1,5 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Wrapper, CardList } from '@components';
+import styled from '@emotion/styled';
+import { getSeries } from '@apis/series';
+import { Link } from 'react-router-dom';
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 
-const WriteListPage = () => <div />;
+const WriteListPage = () => {
+  const [series, setSeries] = useState([]);
+
+  const getInitialData = async () => {
+    const response = await getSeries({ url: '/series' });
+    setSeries(response.data);
+  };
+
+  useEffect(() => {
+    getInitialData();
+  }, []);
+  return (
+    <Wrapper>
+      <Container>
+        <Span>
+          <H1>연재중인 시리즈</H1>
+          <StyeldAddCircleOutlineIcon />
+          <Link to="series-write">새 시리즈 작성하기</Link>
+        </Span>
+        <CardList list={series} />
+      </Container>
+    </Wrapper>
+  );
+};
 
 export default WriteListPage;
+
+const H1 = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+  margin-right: 1rem;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  margin-top: 5rem;
+`;
+
+const Span = styled.span`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const StyeldAddCircleOutlineIcon = styled(AddCircleOutlineIcon)`
+  color: #4b4b4b;
+`;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

작가, 유저의 시리즈/아티클 작성 페이지로 넘어갈 수 있는 페이지입니다!
현재 api가 만들어지지않아 getSeries response를 

## 📝 Results

> 구현한 결과를 첨부합니다.

![스크린샷 2021-12-08 오후 7 38 36](https://user-images.githubusercontent.com/69751205/145195105-277d7611-201c-406d-beed-0b45821bb4bc.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.

api 나오면 붙이겠습니다~~!