### PR TITLE
feat: 시리즈/아티클 연재 페이지 마크업, 기능 구현

### DIFF
--- a/src/pages/WriteListPage/index.jsx
+++ b/src/pages/WriteListPage/index.jsx
@@ -1,5 +1,54 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { Wrapper, CardList } from '@components';
+import styled from '@emotion/styled';
+import { getSeries } from '@apis/series';
+import { Link } from 'react-router-dom';
+import AddCircleOutlineIcon from '@material-ui/icons/AddCircleOutline';
 
-const WriteListPage = () => <div />;
+const WriteListPage = () => {
+  const [series, setSeries] = useState([]);
+
+  const getInitialData = async () => {
+    const response = await getSeries({ url: '/series' });
+    setSeries(response.data);
+  };
+
+  useEffect(() => {
+    getInitialData();
+  }, []);
+  return (
+    <Wrapper>
+      <Container>
+        <Span>
+          <H1>연재중인 시리즈</H1>
+          <StyeldAddCircleOutlineIcon />
+          <Link to="series-write">새 시리즈 작성하기</Link>
+        </Span>
+        <CardList list={series} />
+      </Container>
+    </Wrapper>
+  );
+};
 
 export default WriteListPage;
+
+const H1 = styled.h1`
+  font-size: 2rem;
+  font-weight: 700;
+  margin-right: 1rem;
+`;
+
+const Container = styled.div`
+  width: 100%;
+  margin-top: 5rem;
+`;
+
+const Span = styled.span`
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+`;
+
+const StyeldAddCircleOutlineIcon = styled(AddCircleOutlineIcon)`
+  color: #4b4b4b;
+`;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- 연재 페이지 마크업을 했습니다.
- 연재 페이지 기능을 구현했습니다.
- getSeries api로 더미데이터를 연동시켰습니다.

## 📝 Results

> 구현한 결과를 첨부합니다.

![145195105-277d7611-201c-406d-beed-0b45821bb4bc](https://user-images.githubusercontent.com/69751205/145367830-c9221501-7b6c-40e8-99d6-2dd136c5c4c3.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
