### PR TITLE
feat: [MON-107] channelPage-api구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,6 @@ import {
   ChannelPage,
   EditMyInfoPage,
   HomePage,
-  MyChannelPage,
   MyInfoPage,
   PurchaseHistoryPage,
   PurchasePage,
@@ -45,7 +44,6 @@ const App = () => {
         </Route>
         <Route path="/my/info" exact component={MyInfoPage} />
         <Route path="/my/edit" exact component={EditMyInfoPage} />
-        <Route path="/my/channel" exact component={MyChannelPage} />
         <Route path="/channel/:id" exact component={ChannelPage} />
         <Route path="/purchase" exact component={PurchasePage} />
         <Route path="/purchase/info" exact component={PurchaseHistoryPage} />

--- a/src/apis/channel.jsx
+++ b/src/apis/channel.jsx
@@ -1,0 +1,19 @@
+import { GET } from './axios';
+
+export const getMyChannel = async () => {
+  const response = await GET({
+    url: `/channel/me`,
+    isAuth: true,
+  });
+
+  return response.data;
+};
+
+export const getChannel = async id => {
+  const response = await GET({
+    url: `/channel/users/${id}/other`,
+    isAuth: true,
+  });
+
+  return response.data;
+};

--- a/src/apis/channel.jsx
+++ b/src/apis/channel.jsx
@@ -1,19 +1,13 @@
 import { GET } from './axios';
 
-export const getMyChannel = async () => {
-  const response = await GET({
+export const getMyChannel = async () =>
+  GET({
     url: `/channel/me`,
     isAuth: true,
   });
 
-  return response.data;
-};
-
-export const getChannel = async id => {
-  const response = await GET({
+export const getChannel = async id =>
+  GET({
     url: `/channel/users/${id}/other`,
     isAuth: true,
   });
-
-  return response.data;
-};

--- a/src/apis/series.jsx
+++ b/src/apis/series.jsx
@@ -2,10 +2,10 @@ import { GET, POST, PUT } from './axios';
 
 export const getSeries = async () => {
   const response = await GET({
-    url: `/series/sort?sort=RECENT`,
+    url: `/series/all?size=16`,
     isAuth: false,
   });
-  return response;
+  return response.data;
 };
 
 export const getSeriesDetail = async ({ params }) => {

--- a/src/apis/series.jsx
+++ b/src/apis/series.jsx
@@ -1,20 +1,16 @@
 import { GET, POST, PUT } from './axios';
 
-export const getSeries = async () => {
-  const response = await GET({
+export const getSeries = async () =>
+  GET({
     url: `/series/all?size=16`,
     isAuth: false,
   });
-  return response.data;
-};
 
-export const getSeriesDetail = async ({ params }) => {
-  const response = await GET({
+export const getSeriesDetail = async ({ params }) =>
+  GET({
     url: `/series/${params}`,
     isAuth: false,
   });
-  return response;
-};
 
 export const postSeries = async data => {
   const response = await POST({

--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -3,75 +3,66 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import convertCategory from '@utils/convertCategory';
-import { Icons, Image } from '@components'
+import { Icons, Image } from '@components';
 
 const CardList = ({ list, ...props }) => (
-    <CardContainer {...props}>
-      {
-        list.map(( item ) =>
-          <Card key={ item.series.id }>
-            {
-              item.subscribe.status === 'SUBSCRIPTION_AVAILABLE' ?
-                <SubscribeStatusDiv>
-                  <div className='available'>모집중</div>
-                </SubscribeStatusDiv> :
-                <SubscribeStatusDiv>
-                <div className='unAvailable'>연재중</div>
-              </SubscribeStatusDiv>
-            }
-            <div className='card-imageArea'>
-              <Link to={`/series/${ item.series.id }`}>
-                <Image src={ item.series.thumbnail } width='100%' height='100%' alt={`cardThumb-${item.series.id}`} />
-              </Link>
+  <CardContainer {...props}>
+    {list.map(item => (
+      <Card key={item.seriesId}>
+        {item.subscribeStatus === 'SUBSCRIPTION_AVAILABLE' ? (
+          <SubscribeStatusDiv>
+            <div className="available">모집중</div>
+          </SubscribeStatusDiv>
+        ) : (
+          <SubscribeStatusDiv>
+            <div className="unAvailable">연재중</div>
+          </SubscribeStatusDiv>
+        )}
+        <div className="card-imageArea">
+          <Link to={`/series/${item.seriesIdid}`}>
+            <Image
+              src={item.thumbnail}
+              width="100%"
+              height="100%"
+              alt={`cardThumb-${item.seriesIdid}`}
+            />
+          </Link>
+        </div>
+        <div className="card-textArea">
+          <div>
+            <div className="card-userId">
+              <Link to={`/channel/${item.userId}`}>{item.nickname}</Link>
             </div>
-            <div className='card-textArea'>
-              <div>
-                <div className='card-userId'>
-                  <Link to={`/channel/${ item.writer.userId }`}>
-                    {item.writer.nickname}
-                  </Link>
-                </div>
-                <div className='card-likes'>
-                  <Icons.Like />
-                  { item.series.likes } Likes
-                </div>
-              </div>
-              <div className="card-title">
-                <Link to={`/series/${item.series.id}`}>
-                  { item.series.title }
-                </Link>
-              </div>
-              <div>
-                { item.series.introduceSentence }
-              </div>
-              <div>
-                <div className='category'>
-                  {
-                    convertCategory(item.category)
-                  }
-                </div>
-                <div>
-                  {
-                    item.subscribe.status === 'SUBSCRIPTION_AVAILABLE' ?
-                      `모집마감 ~ ${ item.subscribe.endDate }` :
-                      `연재종료 ~ ${ item.series.endDate }`
-                  }
-                </div>
-              </div>
+            <div className="card-likes">
+              <Icons.Like />
+              {item.likes} Likes
             </div>
-          </Card>
-        )
-      }
-    </CardContainer>
-  );
+          </div>
+          <div className="card-title">
+            <Link to={`/series/${item.seriesId}`}>{item.title}</Link>
+          </div>
+          <div>{item.introduceSentence}</div>
+          <div>
+            <div className="category">{convertCategory(item.category)}</div>
+            <div>
+              {item.subscribeStatus === 'SUBSCRIPTION_AVAILABLE'
+                ? `모집마감 ~ ${item.subscribeEndDate}`
+                : `연재종료 ~ ${item.seriesEndDate}`}
+            </div>
+          </div>
+        </div>
+      </Card>
+    ))}
+  </CardContainer>
+);
 
 CardList.defaultProps = {
   list: [],
-}
+};
 
 CardList.propTypes = {
   list: PropTypes.array,
-}
+};
 
 export default CardList;
 
@@ -79,36 +70,29 @@ const CardContainer = styled.div`
   width: 100%;
   height: auto;
   display: flex;
-  flex-flow : row wrap;
+  flex-flow: row wrap;
 `;
 
-/* 
-  카드 컨텐츠의 width는 100%에서 컨텐츠 개수 대비 
-  총 margin-right 값(n개면 margin * (n-1))을 제외한 나머지 너비를
-  contentsMaxCount(한줄에 출력될 컨텐츠의 갯수)로 나눈 값이다.
-  웹에서는 한줄에 4개, 타블렛에선 3개, 모바일에선 2개처럼 컨텐츠의 갯수를
-  반응형으로 구현할 경우 contentsMaxCount에 변화를 주면 된다.
-
-  nth-of-type을 사용해 맥스 컨텐츠의 배수(flex-end에 닿는 컨텐츠)에는 마진을 적용하지 않는다.
-*/
 const margin = '1.875rem';
 const contentsMaxCount = 4;
 const Card = styled.div`
-  width: calc((100% - (${ margin } * ${ contentsMaxCount - 1 })) / ${ contentsMaxCount });
-  margin-right: ${ margin };
+  width: calc(
+    (100% - (${margin} * ${contentsMaxCount - 1})) / ${contentsMaxCount}
+  );
+  margin-right: ${margin};
   margin-top: 2.5rem;
   display: flex;
   flex-direction: column;
   position: relative;
 
-  &:nth-of-type(-n+4) {
+  &:nth-of-type(-n + 4) {
     margin-top: 0;
   }
 
-  &:nth-of-type(${ contentsMaxCount }n) {
+  &:nth-of-type(${contentsMaxCount}n) {
     margin-right: 0;
   }
-  
+
   .card {
     &-imageArea {
       height: 11rem;
@@ -137,14 +121,14 @@ const Card = styled.div`
         align-items: center;
         border: 0.0625rem solid #ffb15c;
       }
-      
+
       > div {
         margin-bottom: 0.875rem;
         display: flex;
         justify-content: space-between;
         align-items: center;
       }
-      
+
       > div:last-child {
         margin-bottom: 0;
       }
@@ -154,13 +138,13 @@ const Card = styled.div`
           text-decoration: underline;
         }
       }
-      
+
       .card-title {
         font-size: 1.125rem;
         color: #000000;
         line-height: 1.5rem;
         flex-grow: 1;
-  
+
         &:hover {
           text-decoration: underline;
         }
@@ -173,7 +157,7 @@ const SubscribeStatusDiv = styled.div`
   position: absolute;
   top: 0;
   right: 0;
-  
+
   > * {
     padding: 0.625rem;
   }

--- a/src/components/domain/CardSlider/index.jsx
+++ b/src/components/domain/CardSlider/index.jsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { CardList } from '@components';
 
-const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol }) => {
+const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, children }) => {
   const howManyItemsAre = itemsCountOnRow * itemsCountOnCol;
   const lastSlideIndex = Math.ceil(list.length / howManyItemsAre) - 1;
   const slideNumber = useRef(0);
@@ -22,7 +22,7 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol }) => {
 
   divideList();
 
-  const slideSectionRender = useCallback(() => {
+  const slideSectionRender = () => {
     const result = [];
     for (let i = 0; i <= lastSlideIndex; i += 1) {
       result.push(
@@ -32,12 +32,13 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol }) => {
             slideRef.current[i] = el;
           }}
         >
+          {children}
           <CardList list={newList[i]} />
         </SlideSectionArea>,
       );
     }
     return result;
-  }, []);
+  };
 
   const onIncrease = () => {
     if (slideNumber.current < lastSlideIndex) {
@@ -64,7 +65,6 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol }) => {
       <SlideWrapper>
         <SlideFullArea ref={slideFullRef}>{slideSectionRender()}</SlideFullArea>
       </SlideWrapper>
-
       <div
         className="slide-handler handler-left"
         onClick={() => {
@@ -73,7 +73,6 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol }) => {
       >
         <div>&#60;</div>
       </div>
-
       <div
         className="slide-handler handler-right"
         onClick={() => {
@@ -90,12 +89,14 @@ CardSlider.defaultProps = {
   list: [],
   itemsCountOnRow: 4,
   itemsCountOnCol: 2,
+  children: '',
 };
 
 CardSlider.propTypes = {
   list: PropTypes.array,
   itemsCountOnRow: PropTypes.number,
   itemsCountOnCol: PropTypes.number,
+  children: PropTypes.node,
 };
 
 export default CardSlider;

--- a/src/components/domain/CardSlider/index.jsx
+++ b/src/components/domain/CardSlider/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { CardList } from '@components';
@@ -40,19 +40,19 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, children }) => {
     return result;
   };
 
-  const onIncrease = () => {
+  const onIncrease = useCallback(() => {
     if (slideNumber.current < lastSlideIndex) {
       setSlideSequence(slideSequence + 1);
       slideNumber.current += 1;
     }
-  };
+  }, []);
 
-  const onDecrease = () => {
+  const onDecrease = useCallback(() => {
     if (slideNumber.current > 0) {
       setSlideSequence(slideSequence - 1);
       slideNumber.current -= 1;
     }
-  };
+  }, []);
 
   useEffect(() => {
     slideFullRef.current.style.transform = `translateX(${

--- a/src/components/domain/CardSlider/index.jsx
+++ b/src/components/domain/CardSlider/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import { CardList } from '@components';
@@ -40,19 +40,19 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, children }) => {
     return result;
   };
 
-  const onIncrease = useCallback(() => {
+  const onIncrease = () => {
     if (slideNumber.current < lastSlideIndex) {
       setSlideSequence(slideSequence + 1);
       slideNumber.current += 1;
     }
-  }, []);
+  };
 
-  const onDecrease = useCallback(() => {
+  const onDecrease = () => {
     if (slideNumber.current > 0) {
       setSlideSequence(slideSequence - 1);
       slideNumber.current -= 1;
     }
-  }, []);
+  };
 
   useEffect(() => {
     slideFullRef.current.style.transform = `translateX(${

--- a/src/components/domain/Header/Nav.jsx
+++ b/src/components/domain/Header/Nav.jsx
@@ -14,7 +14,7 @@ const Nav = ({ maxWidth, items, ...props }) => (
         <Link to="/series">구독 모집</Link>
       </li>
       <li>
-        <Link to="/my/channel">내 채널</Link>
+        <Link to="/channel/my">내 채널</Link>
       </li>
     </List>
   </StyledNav>

--- a/src/pages/ChannelPage/index.jsx
+++ b/src/pages/ChannelPage/index.jsx
@@ -13,42 +13,44 @@ import { useParams } from 'react-router-dom';
 const ChannelPage = () => {
   const [data, setData] = useState({});
   const { id } = useParams();
-  const thisRef = useRef();
+  const thisDataRef = useRef();
+  const isEmptyRef = useRef(true);
 
   const getInitialData = async () => {
-    thisRef.current = null;
+    thisDataRef.current = null;
 
     if (id === 'my') {
-      const response = await getMyChannel();
-      thisRef.current = response;
-      setData(thisRef.current);
+      const { data } = await getMyChannel();
+      thisDataRef.current = data;
+      setData(thisDataRef.current);
     } else {
-      const response = await getChannel(id);
-      thisRef.current = response;
-      setData(thisRef.current);
+      const { data } = await getChannel(id);
+      thisDataRef.current = data;
+      setData(thisDataRef.current);
     }
-  };
-
-  const isEmpty = param => {
-    if (!param) {
-      return true;
-    }
-    return false;
   };
 
   const userStatus = () => {
-    if (thisRef.current.seriesPostList.length === 0) {
+    if (thisDataRef.current.seriesPostList.length === 0) {
       return '사용자';
     }
     return '작가';
   };
 
+  const isEmpty = param => {
+    if (!param) {
+      isEmptyRef.current = true;
+    }
+    isEmptyRef.current = false;
+  };
+
   useEffect(() => {
     getInitialData();
+    isEmpty(data);
   }, [id]);
 
-  if (!isEmpty(thisRef.current)) {
-    return (
+  return (
+    !isEmptyRef.current && (
       <>
         <ProfileWrapper>
           <ProfileContainer>
@@ -165,9 +167,8 @@ const ChannelPage = () => {
           ) : null}
         </Wrapper>
       </>
-    );
-  }
-  return '';
+    )
+  );
 };
 
 export default ChannelPage;

--- a/src/pages/ChannelPage/index.jsx
+++ b/src/pages/ChannelPage/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import {
   Wrapper,
@@ -7,114 +7,170 @@ import {
   PageSectionContainer,
   CardSlider,
 } from '@components';
-import dummy from '@dummys/cardListDummy.json';
+import { getMyChannel, getChannel } from '@apis/channel';
+import { useParams } from 'react-router-dom';
 
-const ChannelPage = () => (
-  <>
-    <ProfileWrapper>
-      <ProfileContainer>
-        <div>
-          <UserProfile imageOnly />
-        </div>
-        <div className="channel-introduce">
-          <div>
-            <div>박예진</div>
-            <div className="writterTag">작가</div>
-          </div>
-          <div>
-            저는 서울 성북구에 거주중이고 프론트엔드를 배우고 있습니다.
-            <br />이 프로젝트에 참가하게 되어 기쁘게 생각합니다.
-          </div>
-        </div>
-        <div>
-          <div className="follows-wrap">
-            <div>32</div>
-            팔로잉
-          </div>
-          <div className="follows-wrap">
-            <div>100</div>
-            팔로워
-          </div>
-        </div>
-      </ProfileContainer>
-    </ProfileWrapper>
+const ChannelPage = () => {
+  const [data, setData] = useState({});
+  const { id } = useParams();
+  const thisRef = useRef();
 
-    <Wrapper>
-      <PageSectionTitle text="팔로우 한 작가들" />
-      <PageSectionContainer>
-        <WriterContainer>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-          <WriterWrapper>
-            <div className="channel-writer">
-              <div />
-              <div>닉네임</div>
-            </div>
-          </WriterWrapper>
-        </WriterContainer>
-      </PageSectionContainer>
+  const getInitialData = async () => {
+    thisRef.current = null;
 
-      <PageSectionTitle text="구독한 시리즈" />
-      <PageSectionContainer>
-        <CardSlider list={dummy.data} />
-      </PageSectionContainer>
+    if (id === 'my') {
+      const response = await getMyChannel();
+      thisRef.current = response;
+      setData(thisRef.current);
+    } else {
+      const response = await getChannel(id);
+      thisRef.current = response;
+      setData(thisRef.current);
+    }
+  };
 
-      <PageSectionTitle text="생성한 시리즈" />
-    </Wrapper>
-  </>
-);
+  const isEmpty = param => {
+    if (!param) {
+      return true;
+    }
+    return false;
+  };
+
+  const userStatus = () => {
+    if (thisRef.current.seriesPostList.length === 0) {
+      return '사용자';
+    }
+    return '작가';
+  };
+
+  useEffect(() => {
+    getInitialData();
+  }, [id]);
+
+  if (!isEmpty(thisRef.current)) {
+    return (
+      <>
+        <ProfileWrapper>
+          <ProfileContainer>
+            <div>
+              <UserProfile imageOnly src={data.user.profileImage} />
+            </div>
+            <div className="channel-introduce">
+              <div>
+                <div>{data.user.nickname}</div>
+                <div className="writterTag">{userStatus()}</div>
+              </div>
+              <div>{data.user.profileIntroduce}</div>
+            </div>
+            <div>
+              <div className="follows-wrap">
+                <div>32</div>
+                팔로잉
+              </div>
+              <div className="follows-wrap">
+                <div>100</div>
+                팔로워
+              </div>
+            </div>
+          </ProfileContainer>
+        </ProfileWrapper>
+
+        <Wrapper>
+          <PageSectionTitle text="팔로우 한 작가들" />
+          <PageSectionContainer>
+            <WriterContainer>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+              <WriterWrapper>
+                <div className="channel-writer">
+                  <div />
+                  <div>닉네임</div>
+                </div>
+              </WriterWrapper>
+            </WriterContainer>
+          </PageSectionContainer>
+
+          {id === 'my' ? (
+            <>
+              <PageSectionTitle text="관심 시리즈" />
+              <PageSectionContainer>
+                <CardSlider list={data.likeList} />
+              </PageSectionContainer>
+
+              <PageSectionTitle text="구독한 시리즈" />
+              <PageSectionContainer>
+                <CardSlider list={data.subscribeList} />
+              </PageSectionContainer>
+            </>
+          ) : null}
+          {userStatus() === '작가' ? (
+            <>
+              <PageSectionTitle text="생성한 시리즈" />
+              <PageSectionContainer>
+                <CardSlider list={data.seriesPostList} />
+              </PageSectionContainer>
+            </>
+          ) : null}
+        </Wrapper>
+      </>
+    );
+  }
+  return '';
+};
+
+export default ChannelPage;
 
 const ProfileWrapper = styled.div`
   width: 100%;
@@ -213,5 +269,3 @@ const WriterWrapper = styled.div`
     }
   }
 `;
-
-export default ChannelPage;

--- a/src/pages/SeriesDetailPage/index.jsx
+++ b/src/pages/SeriesDetailPage/index.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Wrapper, SeriesDetail } from '@components';
 import { useParams } from 'react-router-dom';
 import { getSeriesDetail } from '@apis/series';
@@ -6,31 +6,32 @@ import { getSeriesDetail } from '@apis/series';
 const SeriesDetailPage = () => {
   const { id } = useParams();
   const [details, setDetails] = useState({});
+  const isEmptyRef = useRef(true);
 
   const getInitialData = async () => {
-    const response = await getSeriesDetail({ params: id });
-    setDetails(response);
+    const { data } = await getSeriesDetail({ params: id });
+    setDetails(data);
+  };
+
+  const isEmpty = param => {
+    if (!param) {
+      isEmptyRef.current = true;
+    }
+    isEmptyRef.current = false;
   };
 
   useEffect(() => {
     getInitialData();
+    isEmpty(details);
   }, []);
-  const getDetails = details.data;
 
-  function isEmpty(data) {
-    if (typeof data === 'undefined' || data === null || data === '')
-      return true;
-    return false;
-  }
-
-  if (isEmpty(getDetails) !== true) {
-    return (
+  return (
+    !isEmptyRef.current && (
       <Wrapper>
-        <SeriesDetail detail={getDetails} />
+        <SeriesDetail detail={details} />
       </Wrapper>
-    );
-  }
-  return '';
+    )
+  );
 };
 
 export default SeriesDetailPage;

--- a/src/pages/SeriesListPage/index.jsx
+++ b/src/pages/SeriesListPage/index.jsx
@@ -6,8 +6,8 @@ const SeriesListPage = () => {
   const [list, setList] = useState([]);
 
   const getInitialData = async () => {
-    const response = await getSeries();
-    setList(response);
+    const { data } = await getSeries();
+    setList(data);
   };
 
   useEffect(() => {

--- a/src/pages/SeriesListPage/index.jsx
+++ b/src/pages/SeriesListPage/index.jsx
@@ -32,7 +32,7 @@ const SeriesListPage = () => {
           ]}
         />
       </SelectContainer>
-      <CardList list={list.data} />
+      <CardList list={list.seriesList} />
     </Wrapper>
   );
 };


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- 채널 페이지 따라서 모집공고 리스트의 데이터 구조&엔드포인트 바뀐거 적용했습니다.(무한스크롤링은 아직)
- 채널페이지 다른사람 채널페이지 확인 가능합니다. 현재는 다른사람채널 페이지도 로그인 후 확인 가능합니다.
- channel/4를 확인해보시면 다른유저가 작가가 아닐때 그 사람이 팔로잉한 사람만 표시되는 걸 확인할 수 있습니다.

## 📝 Results

> 구현한 결과를 첨부합니다.
![image](https://user-images.githubusercontent.com/88189402/145772643-6da62656-f524-4824-8ad5-b2da0216e78b.png)


## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
- channelPage에 팔로잉한 사람 목록은 아직 별도의 컴포넌트로 뺴지 않았습니다.
