### PR TITLE
refactor: [MON-201] 헤더 및 검색 페이지 리팩토링

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ const App = () => {
   const isAuth = sessionStorage.getItem('authorization');
   return (
     <BrowserRouter>
+      <Header />
       <Switch>
         <Route path="/" exact component={HomePage} />
         <Route path="/signup" exact component={SignUpPage} />
@@ -71,7 +72,6 @@ const App = () => {
         />
         <Route path="*" component={NotFoundPage} />
       </Switch>
-      <Header />
     </BrowserRouter>
   );
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Header from '@components/domain/Header';
-import { Route, Switch, Redirect } from 'react-router-dom';
+import { Header } from '@components';
+import { Route, Switch, Redirect, BrowserRouter } from 'react-router-dom';
 import {
   ArticleDetailPage,
   ChannelPage,
@@ -25,7 +25,7 @@ import {
 const App = () => {
   const isAuth = sessionStorage.getItem('authorization');
   return (
-    <Header>
+    <BrowserRouter>
       <Switch>
         <Route path="/" exact component={HomePage} />
         <Route path="/signup" exact component={SignUpPage} />
@@ -71,7 +71,8 @@ const App = () => {
         />
         <Route path="*" component={NotFoundPage} />
       </Switch>
-    </Header>
+      <Header />
+    </BrowserRouter>
   );
 };
 

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import { useSessionStorage } from '@hooks';
-import { BrowserRouter, Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { Link } from 'react-router-dom';
+// import PropTypes from 'prop-types';
 import { Button, Icons } from '@components';
 import theme from '@styles/theme';
 import { lighten } from 'polished';
@@ -11,46 +11,40 @@ import Logo from './Logo';
 
 const logo = require('./logo.svg');
 
-const Header = ({ children }) => {
+const Header = () => {
   const { storedValue } = useSessionStorage('authorization', '');
 
   return (
-    <BrowserRouter>
-      <StyledHeader>
-        <Logo src={logo.default} alt="미리보기" />
-        <Nav items={['Home', '연재하기', '내 채널']} />
-        <Utils>
-          <Link to="/search">
-            <SearchBox>
-              <StyledSearchIcon />
-            </SearchBox>
-          </Link>
-          <Link to="/writes">
-            <StyledButton width="6rem" circle isLogin={storedValue}>
-              글쓰기
-            </StyledButton>
-          </Link>
-          <Link to="/my/info">
-            <Icons.User style={{ display: storedValue ? 'inline' : 'none' }} />
-          </Link>
-          <Link
-            to="/signin"
-            style={{ display: storedValue ? 'none' : 'inline' }}
-          >
-            로그인
-          </Link>
-        </Utils>
-      </StyledHeader>
-      {children}
-    </BrowserRouter>
+    <StyledHeader>
+      <Logo src={logo.default} alt="미리보기" />
+      <Nav items={['Home', '연재하기', '내 채널']} />
+      <Utils>
+        <Link to="/search">
+          <SearchBox>
+            <StyledSearchIcon />
+          </SearchBox>
+        </Link>
+        <Link to="/writes">
+          <StyledButton width="6rem" circle isLogin={storedValue}>
+            글쓰기
+          </StyledButton>
+        </Link>
+        <Link to="/my/info">
+          <Icons.User style={{ display: storedValue ? 'inline' : 'none' }} />
+        </Link>
+        <Link to="/signin" style={{ display: storedValue ? 'none' : 'inline' }}>
+          로그인
+        </Link>
+      </Utils>
+    </StyledHeader>
   );
 };
-Header.propTypes = {
-  children: PropTypes.oneOfType([
-    PropTypes.arrayOf(PropTypes.node),
-    PropTypes.node,
-  ]).isRequired,
-};
+// Header.propTypes = {
+//   children: PropTypes.oneOfType([
+//     PropTypes.arrayOf(PropTypes.node),
+//     PropTypes.node,
+//   ]).isRequired,
+// };
 
 export default Header;
 

--- a/src/pages/general/SearchPage.jsx
+++ b/src/pages/general/SearchPage.jsx
@@ -31,8 +31,7 @@ const SearchPage = () => {
   });
 
   return (
-    <Container>
-      <H1>리스트 검색</H1>
+    <Container title="리스트 검색">
       <SearchForm onSubmit={handleSubmit}>
         <span>
           <Input
@@ -72,13 +71,6 @@ const SearchPage = () => {
 };
 
 export default SearchPage;
-
-const H1 = styled.h1`
-  width: 100%;
-  font-weight: 700;
-  font-size: 1.5rem;
-  padding: 0.5rem 0;
-`;
 
 const ErrorMessage = styled.div`
   color: #ff0000;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- App.jsx가 헤더에 종속적이었던 기존 구조를 바꿨습니다.
- 검색 페이지에 Container prop이 적용되어 있지않아 적용시켰습니다!

## 📝 Results

> 구현한 결과를 첨부합니다.

![스크린샷 2021-12-16 오후 6 00 29](https://user-images.githubusercontent.com/69751205/146340650-b56d9210-9781-48cc-9331-cea73ff63048.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.

위 사진을 보시면 App.jsx안에 BrowserRouter가 들어가고, 헤더를 children으로 가지게되는 구조로 바꿨어요.

App.jsx는 최상위 컴포넌트인데, 헤더에 종속적인것이 문맥상으로나, Router를 사용하는 예제랑 비교했을 때도 맞지 않다고 판단했습니다.

