### PR TITLE
feat: replace enter tag util추가

### DIFF
--- a/src/components/domain/DetailForm/index.jsx
+++ b/src/components/domain/DetailForm/index.jsx
@@ -49,7 +49,7 @@ const DetailForm = ({
       )}
     </DetailInfo>
     <DetailBody>
-      <div
+      <InnerText
         dangerouslySetInnerHTML={{
           __html: replaceEnter(bodyText),
         }}
@@ -180,3 +180,5 @@ const DetailBody = styled.div`
     text-align: right;
   }
 `;
+
+const InnerText = styled.div``;

--- a/src/components/domain/DetailForm/index.jsx
+++ b/src/components/domain/DetailForm/index.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import theme from '@styles/theme';
 import { Button, Image, LikeToggle } from '@components';
+import replaceEnter from '@utils/replaceEnter';
 
 const DetailForm = ({
   previousRoot,
@@ -48,7 +49,11 @@ const DetailForm = ({
       )}
     </DetailInfo>
     <DetailBody>
-      <div>{bodyText}</div>
+      <div
+        dangerouslySetInnerHTML={{
+          __html: replaceEnter(bodyText),
+        }}
+      />
       <div>
         {isMine ? (
           <Link to={`/series/edit/${parentId}`}>

--- a/src/pages/article/ArticleDetailPage.jsx
+++ b/src/pages/article/ArticleDetailPage.jsx
@@ -4,6 +4,7 @@ import { Wrapper, Button, Loading } from '@components';
 import { getArticleDetail } from '@apis/article';
 import { useParams, useHistory } from 'react-router-dom';
 import theme from '@styles/theme';
+import replaceEnter from '@utils/replaceEnter';
 
 const ArticleDetailPage = () => {
   const history = useHistory();
@@ -72,7 +73,11 @@ const ArticleDetailPage = () => {
             </ImageCover>
           </ImageContainer>
           <Wrapper>
-            <Paragraph>{article.contents}</Paragraph>
+            <Paragraph
+              dangerouslySetInnerHTML={{
+                __html: replaceEnter(article.contents),
+              }}
+            />
           </Wrapper>
         </>
       )}
@@ -84,7 +89,7 @@ export default ArticleDetailPage;
 
 const Container = styled.div`
   background-color: #fff;
-  height: calc(100vh - 5rem);
+  min-height: calc(100vh - 5rem);
   margin-top: 5rem;
 `;
 

--- a/src/pages/follow/FollowListPage.jsx
+++ b/src/pages/follow/FollowListPage.jsx
@@ -76,6 +76,5 @@ const FollowListContainer = styled.div`
   height: 90%;
   border-radius: 20px;
   margin: 0 auto;
-  overflow-y: scroll;
   box-shadow: ${theme.style.boxShadow};
 `;

--- a/src/utils/replaceEnter.jsx
+++ b/src/utils/replaceEnter.jsx
@@ -1,0 +1,11 @@
+const replaceEnter = contents => {
+  let result;
+
+  result = contents.replace(/\r\n/gi, '<br />');
+  result = contents.replace(/\\n/gi, '<br />');
+  result = contents.replace(/\n/gi, '<br />');
+
+  return result;
+};
+
+export default replaceEnter;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- 엔터태그 치환하여 innerHTML 해주는 유틸 추가 및 적용했습니다.

## 📝 Results

> 구현한 결과를 첨부합니다.
![image](https://user-images.githubusercontent.com/88189402/146990892-bc76b7fb-525d-4ee7-bdc2-dd56d57b0fef.png)


## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
