### PR TITLE
refactor: [MON-279] Wrapper컴포넌트 리팩토링 및 적용

### DIFF
--- a/src/components/commons/Container/index.jsx
+++ b/src/components/commons/Container/index.jsx
@@ -35,7 +35,7 @@ const H1 = styled.h1`
 const Wrapper = styled.div`
   width: 80%;
   height: 50%;
-  margin: 15rem auto;
+  margin: 0 auto;
   padding: 2rem;
   border-radius: 0.8rem;
   box-shadow: 0 0.25rem 0.375rem rgba(50, 50, 93, 0.11),

--- a/src/components/commons/Wrapper/index.jsx
+++ b/src/components/commons/Wrapper/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 import theme from '@styles/theme';
+import { css } from '@emotion/react';
 
-const Wrapper = ({ children, width, section, ...props }) => (
-  <StyledDiv width={width} section={section} {...props}>
+const Wrapper = ({ children, width, center, ...props }) => (
+  <StyledDiv width={width} center={center} {...props}>
     {children}
   </StyledDiv>
 );
@@ -13,6 +13,7 @@ const Wrapper = ({ children, width, section, ...props }) => (
 Wrapper.defaultProps = {
   width: '71.25rem',
   section: false,
+  center: false,
 };
 
 Wrapper.propTypes = {
@@ -22,6 +23,7 @@ Wrapper.propTypes = {
   ]).isRequired,
   width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   section: PropTypes.bool,
+  center: PropTypes.bool,
 };
 
 export default Wrapper;
@@ -31,18 +33,20 @@ const StyledDiv = styled.div`
   max-width: ${props => props.width || '71.25rem'};
   margin: 0 auto;
   padding: 3rem 0;
-  ${({ section }) =>
-    !section &&
+  margin: 5rem auto 0;
+  ${({ center }) =>
+    center &&
     css`
-      margin: 5rem auto 0;
-      @media ${theme.device.tablet} {
-        max-width: 100%;
-        padding: 3rem 2.5rem;
-      }
-
-      @media ${theme.device.mobile} {
-        max-width: 100%;
-        padding: 3rem 1rem;
-      }
+      display: flex;
+      height: calc(100vh - ${theme.common.navHeight});
+      align-items: center;
     `}
+  @media ${theme.device.tablet} {
+    max-width: 100%;
+    padding: 3rem 2.5rem;
+  }
+  @media ${theme.device.mobile} {
+    max-width: 100%;
+    padding: 3rem 1rem;
+  }
 `;

--- a/src/components/domain/ArticleForm/index.jsx
+++ b/src/components/domain/ArticleForm/index.jsx
@@ -74,7 +74,7 @@ const ArticleForm = ({ edit, param, articleData, ...props }) => {
 
   return (
     <Form onSubmit={handleSubmit} {...props}>
-      <StyledImageUpload
+      <ImageUpload
         onChange={handleImageUpload}
         name="thumbnail"
         src={values.thumbnailUrl}
@@ -102,11 +102,6 @@ export default ArticleForm;
 const Form = styled.form`
   width: 80%;
   margin: 0 auto;
-`;
-
-const StyledImageUpload = styled(ImageUpload)`
-  width: 100vw;
-  margin: 0 0 3rem calc(-50vw + 50%);
 `;
 
 const Buttons = styled(ConfirmCancleButtons)`

--- a/src/components/domain/ImageUpload/index.jsx
+++ b/src/components/domain/ImageUpload/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Upload, Button } from '@components';
-import theme from '@styles/theme';
+import { theme, mixin } from '@styles';
 import { css } from '@emotion/react';
 
 const ImageUpload = ({
@@ -51,12 +51,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  ${({ wide }) =>
-    wide &&
-    css`
-      position: relative;
-      width: 100%;
-    `}
+  ${({ wide }) => wide && mixin.fullScreen}
 `;
 
 const StyledUpload = styled(Upload)`
@@ -64,7 +59,6 @@ const StyledUpload = styled(Upload)`
     wide &&
     css`
       position: absolute;
-      top: 50%;
       top: 50%;
       transform: translateY(-50%);
       z-index: 1;

--- a/src/components/domain/SeriesForm/index.jsx
+++ b/src/components/domain/SeriesForm/index.jsx
@@ -114,14 +114,13 @@ const SeriesForm = ({ edit, param, seriesData, ...props }) => {
 
   return (
     <form onSubmit={handleSubmit} {...props}>
-      <Section>
-        <StyledImageUpload
-          onChange={handleImageUpload}
-          name="thumbnail"
-          src={values.thumbnailUrl}
-          wide={+true}
-        />
-      </Section>
+      <ImageUpload
+        onChange={handleImageUpload}
+        name="thumbnail"
+        src={values.thumbnailUrl}
+        wide={+true}
+      />
+
       <Section>
         <Title size="medium">카테고리</Title>
         <ButtonSelect
@@ -244,11 +243,6 @@ export default SeriesForm;
 
 const Section = styled.section`
   margin-bottom: 3rem;
-`;
-
-const StyledImageUpload = styled(ImageUpload)`
-  width: 100vw;
-  margin-left: calc(-50vw + 50%);
 `;
 
 const StyledFlex = styled(Flex)`

--- a/src/pages/article/ArticleDetailPage.jsx
+++ b/src/pages/article/ArticleDetailPage.jsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import { Wrapper, Button, Loading } from '@components';
 import { getArticleDetail } from '@apis/article';
 import { useParams, useHistory } from 'react-router-dom';
-import theme from '@styles/theme';
+import { theme, mixin } from '@styles';
 import replaceEnter from '@utils/replaceEnter';
 
 const ArticleDetailPage = () => {
@@ -43,7 +43,7 @@ const ArticleDetailPage = () => {
   }, []);
 
   return (
-    <Container>
+    <Wrapper>
       {loading ? (
         <Loading />
       ) : (
@@ -72,35 +72,25 @@ const ArticleDetailPage = () => {
               </Content>
             </ImageCover>
           </ImageContainer>
-          <Wrapper>
-            <Paragraph
-              dangerouslySetInnerHTML={{
-                __html: replaceEnter(article.contents),
-              }}
-            />
-          </Wrapper>
+          <Paragraph
+            dangerouslySetInnerHTML={{
+              __html: replaceEnter(article.contents),
+            }}
+          />
         </>
       )}
-    </Container>
+    </Wrapper>
   );
 };
 
 export default ArticleDetailPage;
 
-const Container = styled.div`
-  background-color: #fff;
-  min-height: calc(100vh - 5rem);
-  margin-top: 5rem;
-`;
-
 const ImageContainer = styled.div`
-  width: 100%;
+  ${mixin.fullScreen}
   height: 30rem;
-  position: relative;
   background-image: ${({ image }) => `url(${image})`};
   background-position: center;
   background-size: cover;
-  margin: 3rem 0;
 `;
 
 const ImageCover = styled.div`
@@ -158,7 +148,6 @@ const Date = styled.span`
 
 const Paragraph = styled.div`
   width: 100%;
-  height: 100%;
   font-size: 1rem;
   line-height: 1.7rem;
 `;

--- a/src/pages/auth/SignInPage.jsx
+++ b/src/pages/auth/SignInPage.jsx
@@ -45,7 +45,7 @@ const SignInPage = () => {
   });
 
   return (
-    <StyledWrapper whole>
+    <Wrapper center>
       <Form onSubmit={handleSubmit}>
         <H1>로그인</H1>
         <Input
@@ -74,15 +74,11 @@ const SignInPage = () => {
         </Span>
         <ErrorMessage>{errors.resError}&nbsp;</ErrorMessage>
       </Form>
-    </StyledWrapper>
+    </Wrapper>
   );
 };
 
 export default SignInPage;
-
-const StyledWrapper = styled(Wrapper)`
-  height: calc(100vh - 5rem);
-`;
 
 const H1 = styled.h1`
   font-size: 2rem;
@@ -92,7 +88,6 @@ const H1 = styled.h1`
 
 const Form = styled.form`
   width: 60%;
-  height: 100%;
   padding: 10rem 0;
   margin: 0 auto;
   text-align: center;

--- a/src/pages/auth/SignUpPage.jsx
+++ b/src/pages/auth/SignUpPage.jsx
@@ -41,7 +41,7 @@ const SignUpPage = () => {
   });
 
   return (
-    <StyledWrapper whole>
+    <Wrapper center>
       <Form onSubmit={handleSubmit}>
         <H1>회원가입</H1>
         <Input
@@ -87,15 +87,11 @@ const SignUpPage = () => {
         <SubmitButton type="submit">회원가입</SubmitButton>
         <ErrorMessage>{errors.resError}&nbsp;</ErrorMessage>
       </Form>
-    </StyledWrapper>
+    </Wrapper>
   );
 };
 
 export default SignUpPage;
-
-const StyledWrapper = styled(Wrapper)`
-  height: calc(100vh - 5rem);
-`;
 
 const H1 = styled.h1`
   font-size: 2rem;
@@ -105,7 +101,6 @@ const H1 = styled.h1`
 
 const Form = styled.form`
   width: 60%;
-  height: 100%;
   padding: 5rem 0;
   margin: 0 auto;
   text-align: center;

--- a/src/pages/channel/ChannelPage.jsx
+++ b/src/pages/channel/ChannelPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import theme from '@styles/theme';
+import { theme, mixin } from '@styles';
 import {
   Wrapper,
   SectionContainer,
@@ -120,7 +120,7 @@ const ChannelPage = () => {
   }, [id, data.isFollowed]);
 
   return (
-    <ChannelContainer>
+    <Wrapper>
       {loading ? (
         <Loading />
       ) : (
@@ -165,48 +165,46 @@ const ChannelPage = () => {
             </ProfileBottom>
           </ProfileWrapper>
 
-          <Wrapper className="customWrapper">
-            {data.followWriterList.length > 0 ? (
-              <UserList
-                list={data.followWriterList}
-                title="팔로우한 작가들"
-                moreLink={id ? `/follow/${id}` : '/follow/my'}
-              />
-            ) : !id ? (
-              <SectionContainer title="팔로우한 작가들">
+          {data.followWriterList.length > 0 ? (
+            <UserList
+              list={data.followWriterList}
+              title="팔로우한 작가들"
+              moreLink={id ? `/follow/${id}` : '/follow/my'}
+            />
+          ) : !id ? (
+            <SectionContainer title="팔로우한 작가들">
+              <NoData>
+                팔로우한 작가가 없습니다. 마음에 드는 작가를 팔로우 해보세요.
+              </NoData>
+            </SectionContainer>
+          ) : null}
+          {!id ? (
+            data.subscribeList.length > 0 ? (
+              <SectionContainer title="구독한 시리즈">
+                <CardSlider list={data.subscribeList} />
+              </SectionContainer>
+            ) : (
+              <SectionContainer title="구독한 시리즈">
                 <NoData>
-                  팔로우한 작가가 없습니다. 마음에 드는 작가를 팔로우 해보세요.
+                  구독한 시리즈가 없습니다. 마음에 드는 시리즈를 찾아보세요.
                 </NoData>
               </SectionContainer>
-            ) : null}
-            {!id ? (
-              data.subscribeList.length > 0 ? (
-                <SectionContainer title="구독한 시리즈">
-                  <CardSlider list={data.subscribeList} />
-                </SectionContainer>
-              ) : (
-                <SectionContainer title="구독한 시리즈">
-                  <NoData>
-                    구독한 시리즈가 없습니다. 마음에 드는 시리즈를 찾아보세요.
-                  </NoData>
-                </SectionContainer>
-              )
-            ) : null}
-            {data.seriesPostList.length > 0 ? (
-              <SectionContainer title="작성한 시리즈">
-                <CardSlider list={data.seriesPostList} />
-              </SectionContainer>
-            ) : !id ? (
-              <SectionContainer title="작성한 시리즈">
-                <NoData>
-                  작성한 시리즈가 없습니다. 새로운 시리즈를 작성해보세요.
-                </NoData>
-              </SectionContainer>
-            ) : null}
-          </Wrapper>
+            )
+          ) : null}
+          {data.seriesPostList.length > 0 ? (
+            <SectionContainer title="작성한 시리즈">
+              <CardSlider list={data.seriesPostList} />
+            </SectionContainer>
+          ) : !id ? (
+            <SectionContainer title="작성한 시리즈">
+              <NoData>
+                작성한 시리즈가 없습니다. 새로운 시리즈를 작성해보세요.
+              </NoData>
+            </SectionContainer>
+          ) : null}
         </>
       )}
-    </ChannelContainer>
+    </Wrapper>
   );
 };
 
@@ -214,19 +212,9 @@ export default ChannelPage;
 
 const ProfileAreaHeight = '27rem';
 
-const ChannelContainer = styled.div`
-  .customWrapper {
-    margin-top: calc(${ProfileAreaHeight} + ${theme.common.navHeight});
-  }
-`;
-
 const ProfileWrapper = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  ${mixin.fullScreen}
   height: ${ProfileAreaHeight};
-  margin-top: ${theme.common.navHeight};
   background-image: url(${cover});
   background-repeat: no-repeat;
   background-size: 100% auto;

--- a/src/pages/follow/FollowListPage.jsx
+++ b/src/pages/follow/FollowListPage.jsx
@@ -50,7 +50,7 @@ const FollowListPage = () => {
   }, [target]);
 
   return (
-    <Wrapper whole>
+    <Wrapper>
       <FollowListContainer>
         {values.length ? (
           values.map(element => (

--- a/src/pages/general/NotFoundPage.jsx
+++ b/src/pages/general/NotFoundPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Wrapper } from '@components';
 
 const NotFoundPage = () => (
-  <Wrapper whole>
+  <Wrapper>
     <h1>404 Not Found</h1>
   </Wrapper>
 );

--- a/src/pages/general/SearchPage.jsx
+++ b/src/pages/general/SearchPage.jsx
@@ -40,7 +40,7 @@ const SearchPage = () => {
   });
 
   return (
-    <Wrapper whole>
+    <Wrapper>
       <div>리스트 검색</div>
       <SearchForm onSubmit={handleSubmit}>
         <div className="optionArea">

--- a/src/pages/general/ServerErrorPage.jsx
+++ b/src/pages/general/ServerErrorPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Wrapper } from '@components';
 
 const ServerErrorPage = () => (
-  <Wrapper whole>
+  <Wrapper>
     <h1>500 Server Error Page</h1>
   </Wrapper>
 );

--- a/src/pages/purchase/PurchasePage.jsx
+++ b/src/pages/purchase/PurchasePage.jsx
@@ -37,7 +37,7 @@ const PurchasePage = () => {
   };
 
   return (
-    <Wrapper>
+    <Wrapper center>
       {isLoading ? (
         <Loading />
       ) : (

--- a/src/pages/series/SeriesDetailPage.jsx
+++ b/src/pages/series/SeriesDetailPage.jsx
@@ -12,7 +12,7 @@ import {
 import { useParams, Link, useHistory } from 'react-router-dom';
 import { getSeriesDetail } from '@apis/series';
 import styled from '@emotion/styled';
-import theme from '@styles/theme';
+import { theme, mixin } from '@styles';
 import convertDay from '@utils/convertDay';
 
 export const initialData = {
@@ -82,7 +82,7 @@ const SeriesDetailPage = () => {
   }, []);
 
   return (
-    <Container>
+    <Wrapper>
       {loading ? (
         <Loading />
       ) : (
@@ -95,107 +95,101 @@ const SeriesDetailPage = () => {
               height="auto"
             />
           </ImageArea>
-          <Wrapper>
-            <MainArea>
-              <div>
-                <DetailForm
-                  previousRoot="/series"
-                  previousRootText="구독 모집"
-                  parentId={detail.series.id}
-                  title={detail.series.title}
-                  writerId={detail.writer.userId}
-                  writerProfileImage={detail.writer.profileImage}
-                  writerNickname={detail.writer.nickname}
-                  postDate={detail.subscribe.startDate}
-                  likes={detail.series.likes}
-                  bodyText={detail.series.introduceText}
-                  isMine={detail.isMine}
-                  isLiked={detail.isLiked}
-                />
-              </div>
-              <InfoArea>
-                <SeriesInfoHead>INFORMATION</SeriesInfoHead>
-                <SeriesInfo>
-                  <SeriesInfoSection>
-                    <div>구독 정보</div>
-                    <div className="seriesInfoBlock">
-                      <div>모집일</div>
-                      {detail.subscribe.startDate} ~ {detail.subscribe.endDate}
-                    </div>
-                    <div className="seriesInfoBlock">
-                      <div>구독료</div>
-                      {detail.series.price} 원
-                    </div>
-                  </SeriesInfoSection>
-                  <SeriesInfoSection>
-                    <div>연재 정보</div>
-                    <div className="seriesInfoBlock">
-                      <div>연재 일</div>
-                      {detail.series.startDate} ~ {detail.series.endDate}
-                    </div>
-                    <div className="seriesInfoBlock">
-                      <div>연재 주기</div>
-                      {convertDay(detail.upload.date).join(', ')}
-                      &nbsp;{detail.upload.time} 시
-                    </div>
-                    <div className="seriesInfoBlock">
-                      <div>총 회차</div>
-                      {detail.series.articleCount} 회
-                    </div>
-                  </SeriesInfoSection>
-                  <SeriesInfoSection>
-                    <Link to={`/purchase/${detail.series.id}`}>
-                      {sessionStorage.getItem('authorization') &&
-                      !detail.isMine ? (
-                        <Button
-                          className="seriesPurchase"
-                          width="100%"
-                          height="2.8125rem"
-                          margin={0}
-                        >
-                          결제하기
-                        </Button>
-                      ) : null}
-                    </Link>
-                  </SeriesInfoSection>
-                </SeriesInfo>
-              </InfoArea>
-            </MainArea>
-            <ArticleArea>
-              <div className="articleAreaHeader">
-                <SectionContainer title="연재 목록" />
-                {detail.isMine ? (
-                  <Link to={`/series/${detail.series.id}/article/write`}>
-                    <ContentAddLink>새 아티클 작성하기</ContentAddLink>
+          <MainArea>
+            <div>
+              <DetailForm
+                previousRoot="/series"
+                previousRootText="구독 모집"
+                parentId={detail.series.id}
+                title={detail.series.title}
+                writerId={detail.writer.userId}
+                writerProfileImage={detail.writer.profileImage}
+                writerNickname={detail.writer.nickname}
+                postDate={detail.subscribe.startDate}
+                likes={detail.series.likes}
+                bodyText={detail.series.introduceText}
+                isMine={detail.isMine}
+                isLiked={detail.isLiked}
+              />
+            </div>
+            <InfoArea>
+              <SeriesInfoHead>INFORMATION</SeriesInfoHead>
+              <SeriesInfo>
+                <SeriesInfoSection>
+                  <div>구독 정보</div>
+                  <div className="seriesInfoBlock">
+                    <div>모집일</div>
+                    {detail.subscribe.startDate} ~ {detail.subscribe.endDate}
+                  </div>
+                  <div className="seriesInfoBlock">
+                    <div>구독료</div>
+                    {detail.series.price} 원
+                  </div>
+                </SeriesInfoSection>
+                <SeriesInfoSection>
+                  <div>연재 정보</div>
+                  <div className="seriesInfoBlock">
+                    <div>연재 일</div>
+                    {detail.series.startDate} ~ {detail.series.endDate}
+                  </div>
+                  <div className="seriesInfoBlock">
+                    <div>연재 주기</div>
+                    {convertDay(detail.upload.date).join(', ')}
+                    &nbsp;{detail.upload.time} 시
+                  </div>
+                  <div className="seriesInfoBlock">
+                    <div>총 회차</div>
+                    {detail.series.articleCount} 회
+                  </div>
+                </SeriesInfoSection>
+                <SeriesInfoSection>
+                  <Link to={`/purchase/${detail.series.id}`}>
+                    {sessionStorage.getItem('authorization') &&
+                    !detail.isMine ? (
+                      <Button
+                        className="seriesPurchase"
+                        width="100%"
+                        height="2.8125rem"
+                        margin={0}
+                      >
+                        결제하기
+                      </Button>
+                    ) : null}
                   </Link>
-                ) : null}
-              </div>
-              <SectionContainer>
-                <ArticleList
-                  seriesId={detail.series.id}
-                  list={detail.articleList}
-                />
-              </SectionContainer>
-            </ArticleArea>
-          </Wrapper>
+                </SeriesInfoSection>
+              </SeriesInfo>
+            </InfoArea>
+          </MainArea>
+          <ArticleArea>
+            <div className="articleAreaHeader">
+              <SectionContainer title="연재 목록" />
+              {detail.isMine ? (
+                <ContentAddLink
+                  url={`/series/${detail.series.id}/article/write`}
+                >
+                  새 아티클 작성하기
+                </ContentAddLink>
+              ) : null}
+            </div>
+            <SectionContainer>
+              <ArticleList
+                seriesId={detail.series.id}
+                list={detail.articleList}
+              />
+            </SectionContainer>
+          </ArticleArea>
         </>
       )}
-    </Container>
+    </Wrapper>
   );
 };
 
 export default SeriesDetailPage;
 
-const Container = styled.div`
-  background-color: #fff;
-`;
-
 const ImageArea = styled.div`
-  width: 100%;
+  ${mixin.fullScreen}
   height: 30rem;
-  position: relative;
   overflow: hidden;
-  margin-top: 5rem;
 
   > * {
     position: absolute;

--- a/src/pages/series/SeriesListPage.jsx
+++ b/src/pages/series/SeriesListPage.jsx
@@ -125,7 +125,7 @@ const SeriesListPage = () => {
   };
 
   return (
-    <Wrapper whole>
+    <Wrapper>
       {isLoading ? (
         <Loading />
       ) : (

--- a/src/pages/user/MyInfoPage.jsx
+++ b/src/pages/user/MyInfoPage.jsx
@@ -15,7 +15,7 @@ const MyInfoPage = () => {
   };
 
   return (
-    <Wrapper>
+    <Wrapper center>
       <Container title="마이 페이지">
         <StyledLink to="/my/edit">내 정보 수정</StyledLink>
         <StyledLink to="/purchase/info">내 구독 내역</StyledLink>

--- a/src/styles/index.jsx
+++ b/src/styles/index.jsx
@@ -1,0 +1,2 @@
+export { default as mixin } from './mixin';
+export { default as theme } from './theme';

--- a/src/styles/mixin.jsx
+++ b/src/styles/mixin.jsx
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+
+const fullScreen = css`
+  position: relative;
+  top: -3rem;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+`;
+
+const mixin = { fullScreen };
+
+export default mixin;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- Wrapper컴포넌트에 whole, section속성 제거 (전체 내용 감쌀 때만 사용 가능 하도록)
- Wrapper컴포넌트에 center props추가 및 적용 (컨텐츠가 많지 않을 때 화면에 정중앙에 오도록)
  - 로그인
  - 로그아웃
  - 마이페이지
  - 결제 페이지들에 적용
- Wrapper컴포넌트에 반응형 코드 추가
- style 폴더에 mixin파일 추가해 브라우저 전체 너비 쓰는 컴포넌트에 공통적으로 적용되는 스타일 작성 및 적용
  - 반복되는 css코드들을 작성하면 될 것 같습니다.

## 📝 Results
![image](https://user-images.githubusercontent.com/81611808/148751443-bcdf9784-75a6-4806-bed5-2b5b751c74ce.png)

![image](https://user-images.githubusercontent.com/81611808/148751251-0ce6050d-b65f-432c-9fec-fec2122b1f02.png)


## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.
