### PR TITLE
feat: [MON-284] 반응형 헤더 및 네비게이션 모달 추가

### DIFF
--- a/src/components/domain/Header/LaptopHeader.jsx
+++ b/src/components/domain/Header/LaptopHeader.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import styled from '@emotion/styled';
+import { Link } from 'react-router-dom';
+import { Button, Icons } from '@components';
+import theme from '@styles/theme';
+import { lighten } from 'polished';
+import { css } from '@emotion/react';
+import PropTypes from 'prop-types';
+import Nav from './Nav';
+import Logo from './Logo';
+
+const logo = require('./logo_whiteBackboard.svg');
+
+const LaptopHeader = ({ userId }) => (
+  <StyledHeader>
+    <Logo src={logo.default} alt="미리보기" />
+    <StyledNav items={['Home', '연재하기', '내 채널']} />
+    <Utils islogin={userId}>
+      <SearchLink to="/search" islogin={userId}>
+        <SearchBox>
+          <StyledSearchIcon />
+        </SearchBox>
+      </SearchLink>
+      {userId ? (
+        <>
+          <Link to="/writes">
+            <StyledButton width="6rem" circle>
+              글쓰기
+            </StyledButton>
+          </Link>
+          <Link to="/my/info">
+            <Icons.User />
+          </Link>
+        </>
+      ) : (
+        <LoginLink to="/signin">로그인</LoginLink>
+      )}
+    </Utils>
+  </StyledHeader>
+);
+
+LaptopHeader.defaultProps = {
+  userId: 0,
+};
+
+LaptopHeader.propTypes = {
+  userId: PropTypes.number,
+};
+
+export default LaptopHeader;
+
+const StyledHeader = styled.header`
+  position: fixed;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: ${theme.common.navHeight};
+  padding: 0 3rem;
+  top: 0;
+  background-color: #fff;
+  box-shadow: 0 0.05rem 0.1rem 0 rgba(50, 50, 93, 0.15);
+  z-index: 2;
+  a:hover {
+    color: ${theme.color.main};
+    transition: all 200ms ease-out;
+  }
+
+  @media ${theme.device.tablet} {
+    display: none;
+  }
+
+  @media ${theme.device.mobile} {
+    display: none;
+  }
+`;
+
+const StyledNav = styled(Nav)`
+  width: 100%;
+  margin: 0 4rem;
+`;
+
+const StyledSearchIcon = styled(Icons.Search)`
+  margin-right: 0.3rem;
+`;
+
+const SearchBox = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  width: 10rem;
+  padding: 0.2rem;
+  border-radius: 4px;
+  background-color: ${theme.color.greyLight};
+  &:hover {
+    outline: 0.0625rem solid ${theme.color.main};
+    background-color: ${lighten(0.01, theme.color.greyLight)};
+    ${StyledSearchIcon} {
+      color: ${theme.color.main};
+    }
+  }
+`;
+
+const Utils = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  max-width: 17rem;
+  ${({ islogin }) =>
+    islogin &&
+    css`
+      max-width: 23rem;
+    `}
+`;
+
+const SearchLink = styled(Link)`
+  margin-right: 1.5rem;
+  ${({ islogin }) =>
+    islogin &&
+    css`
+      margin-right: 2.5rem;
+    `}
+`;
+
+const StyledButton = styled(Button)`
+  margin-right: 1rem;
+`;
+
+const LoginLink = styled(Link)`
+  flex-shrink: 0;
+`;

--- a/src/components/domain/Header/Logo.jsx
+++ b/src/components/domain/Header/Logo.jsx
@@ -15,9 +15,9 @@ Logo.defaultProps = {
   alt: 'Logo',
 };
 
-export default Logo;
-
 Logo.propTypes = {
   src: PropTypes.string,
   alt: PropTypes.string,
 };
+
+export default Logo;

--- a/src/components/domain/Header/ResponsiveHeader.jsx
+++ b/src/components/domain/Header/ResponsiveHeader.jsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import styled from '@emotion/styled';
+import theme from '@styles/theme';
+import MenuIcon from '@material-ui/icons/Menu';
+import { IconWrapper, Flex } from '@components';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { useClickAway } from '@hooks';
+import Logo from './Logo';
+
+const logo = require('./logo_whiteBackboard.svg');
+
+const ResponsiveHeader = ({ userId }) => {
+  const [isOpened, setIsOpened] = useState(false);
+  const ref = useClickAway(() => {
+    setIsOpened(false);
+  });
+
+  const handleMenuClick = () => {
+    setIsOpened(prev => !prev);
+  };
+
+  const handleBackgroundClick = e => {
+    if (e.target !== e.currentTarget) return;
+    setIsOpened(false);
+  };
+
+  return (
+    <Header>
+      <Logo src={logo.default} alt="미리보기" />
+      <IconWrapper fontSize="2rem">
+        <StyledMenuIcon onClick={handleMenuClick} />
+      </IconWrapper>
+      {isOpened && (
+        <NavContainer ref={ref} onClick={handleBackgroundClick}>
+          <StyledFlex width="100%" justifyContent="center">
+            <li>
+              <Link to="/" onClick={handleMenuClick}>
+                Home
+              </Link>
+            </li>
+            <li>
+              <Link to="/series" onClick={handleMenuClick}>
+                구독 모집
+              </Link>
+            </li>
+            <li>
+              <Link to="/channel/my" onClick={handleMenuClick}>
+                내 채널
+              </Link>
+            </li>
+            {userId ? (
+              <li>
+                <Link to="/my/info" onClick={handleMenuClick}>
+                  내 정보
+                </Link>
+              </li>
+            ) : (
+              <li>
+                <Link to="/signin" onClick={handleMenuClick}>
+                  로그인
+                </Link>
+              </li>
+            )}
+          </StyledFlex>
+        </NavContainer>
+      )}
+    </Header>
+  );
+};
+
+ResponsiveHeader.defaultProps = {
+  userId: 0,
+};
+
+ResponsiveHeader.propTypes = {
+  userId: PropTypes.number,
+};
+
+export default ResponsiveHeader;
+
+const Header = styled.header`
+  position: fixed;
+  padding: 0 3rem;
+  top: 0;
+  width: 100%;
+  display: flex;
+  height: ${theme.common.navHeight};
+  align-items: center;
+  z-index: 1;
+  background-color: #fff;
+  box-shadow: 0 0.05rem 0.1rem 0 rgba(50, 50, 93, 0.15);
+
+  justify-content: center;
+
+  @media ${theme.device.laptop} {
+    display: none;
+  }
+`;
+
+const StyledMenuIcon = styled(MenuIcon)`
+  font-size: 4rem;
+  position: absolute;
+  top: 35%;
+  left: 0.5rem;
+  z-index: 2;
+  cursor: pointer;
+`;
+
+const StyledFlex = styled(Flex)`
+  position: absolute;
+  background-color: #fff;
+  padding: 2rem 0;
+  height: 15rem;
+  animation: fadeIn 1s;
+  li {
+    height: 3rem;
+
+    &:hover {
+      color: ${theme.color.main};
+      transition: all 200ms ease-out;
+    }
+  }
+
+  @keyframes fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+`;
+
+const NavContainer = styled.div`
+  position: fixed;
+  top: ${theme.common.navHeight};
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.3);
+`;

--- a/src/components/domain/Header/index.jsx
+++ b/src/components/domain/Header/index.jsx
@@ -1,121 +1,17 @@
 import React from 'react';
-import styled from '@emotion/styled';
-import { Link } from 'react-router-dom';
-import { Button, Icons } from '@components';
-import theme from '@styles/theme';
-import { lighten } from 'polished';
 import { useUser } from '@contexts/UserProvider';
-import { css } from '@emotion/react';
-import Nav from './Nav';
-import Logo from './Logo';
-
-const logo = require('./logo_whiteBackboard.svg');
+import LaptopHeader from './LaptopHeader';
+import ResponsiveHeader from './ResponsiveHeader';
 
 const Header = () => {
   const { userInfo } = useUser();
-
   return (
-    <StyledHeader>
-      <Logo src={logo.default} alt="미리보기" />
-      <StyledNav items={['Home', '연재하기', '내 채널']} />
-      <Utils islogin={userInfo.userId}>
-        <SearchLink to="/search" islogin={userInfo.userId}>
-          <SearchBox>
-            <StyledSearchIcon />
-          </SearchBox>
-        </SearchLink>
-        {userInfo.userId ? (
-          <>
-            <Link to="/writes">
-              <StyledButton width="6rem" circle>
-                글쓰기
-              </StyledButton>
-            </Link>
-            <Link to="/my/info">
-              <Icons.User />
-            </Link>
-          </>
-        ) : (
-          <LoginLink to="/signin">로그인</LoginLink>
-        )}
-      </Utils>
-    </StyledHeader>
+    <>
+      <LaptopHeader userId={userInfo.userId} />
+      <ResponsiveHeader userId={userInfo.userId} />
+      {userInfo.userId}
+    </>
   );
 };
 
 export default Header;
-
-const StyledHeader = styled.header`
-  position: fixed;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  height: ${theme.common.navHeight};
-  padding: 0 3rem;
-  top: 0;
-  background-color: #fff;
-  box-shadow: 0 0.05rem 0.1rem 0 rgba(50, 50, 93, 0.15);
-  z-index: 2;
-  a:hover {
-    color: ${theme.color.main};
-    transition: all 200ms ease-out;
-  }
-`;
-
-const StyledNav = styled(Nav)`
-  width: 100%;
-  min-width: 15rem;
-  margin: 0 4rem;
-`;
-
-const StyledSearchIcon = styled(Icons.Search)`
-  margin-right: 0.3rem;
-`;
-
-const SearchBox = styled.div`
-  display: flex;
-  justify-content: flex-end;
-  align-items: center;
-  width: 10rem;
-  padding: 0.2rem;
-  border-radius: 4px;
-  background-color: ${theme.color.greyLight};
-  &:hover {
-    outline: 0.0625rem solid ${theme.color.main};
-    background-color: ${lighten(0.01, theme.color.greyLight)};
-    ${StyledSearchIcon} {
-      color: ${theme.color.main};
-    }
-  }
-`;
-
-const Utils = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  width: 100%;
-  max-width: 17rem;
-  ${({ islogin }) =>
-    islogin &&
-    css`
-      max-width: 23rem;
-    `}
-`;
-
-const SearchLink = styled(Link)`
-  margin-right: 1.5rem;
-  ${({ islogin }) =>
-    islogin &&
-    css`
-      margin-right: 2.5rem;
-    `}
-`;
-
-const StyledButton = styled(Button)`
-  margin-right: 1rem;
-`;
-
-const LoginLink = styled(Link)`
-  flex-shrink: 0;
-`;

--- a/src/styles/theme.jsx
+++ b/src/styles/theme.jsx
@@ -34,6 +34,7 @@ const deviceSizes = {
 const device = {
   mobile: `screen and (max-width: ${deviceSizes.tablet})`,
   tablet: `screen and (max-width: ${deviceSizes.laptop})`,
+  laptop: `screen and (min-width: ${deviceSizes.laptop}}`,
 };
 
 const theme = {


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

- 모바일, 테블릿용 헤더 구현
- 헤더 네비게이션 기능 구현
- 네비게이션 닫기 및 url 이동 시 자동 닫기 구현 

## 📝 Results

> 구현한 결과를 첨부합니다.

![스크린샷 2022-01-12 오후 7 00 33](https://user-images.githubusercontent.com/69751205/149139183-999adc3d-fb01-49d1-89b0-93c137940c66.png)

## 📝 논의점

> 논의하고 싶은 부분을 적어주세요.

논의했던 반응형 헤더 부분은 다 구현했습니다!
현재 첫 렌더링 시엔 아무런 문제가 없는데, 다른 페이지 이동 후 메인으로 돌아왔을 시 슬라이더와 헤더 사이에 공백이 보여요!
아마 13px로의 변경때문에 생긴 margin-top 때문인것 같습니다. 반응형 다 적용해보고 사라지지않는다면 수정하는게 좋을 것 같아요~
