### PR TITLE
refactor: [MON-283] 결제 페이지, 마이페이지, 관련 컴포넌트 반응형 적용

### DIFF
--- a/src/components/commons/Button/index.jsx
+++ b/src/components/commons/Button/index.jsx
@@ -47,7 +47,7 @@ Button.defaultProps = {
   name: '',
   value: '',
   children: 'text',
-  margin: 1,
+  margin: 0,
   round: true,
 };
 

--- a/src/components/commons/Container/index.jsx
+++ b/src/components/commons/Container/index.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
+import theme from '@styles/theme';
 
-const Container = ({ title, children }) => (
-  <Wrapper>
+const Container = ({ title, children, ...props }) => (
+  <Wrapper {...props}>
     <H1>{title}</H1>
     {children}
   </Wrapper>
@@ -34,11 +35,17 @@ const H1 = styled.h1`
 
 const Wrapper = styled.div`
   width: 80%;
-  height: 50%;
+  height: auto;
   margin: 0 auto;
   padding: 2rem;
   border-radius: 0.8rem;
   box-shadow: 0 0.25rem 0.375rem rgba(50, 50, 93, 0.11),
     0 0.063rem 0.188rem rgba(0, 0, 0, 0.08);
   background-color: #ffffff;
+  @media ${theme.device.tablet} {
+    width: 65%;
+  }
+  @media ${theme.device.mobile} {
+    width: 80%;
+  }
 `;

--- a/src/pages/purchase/PurchasePage.jsx
+++ b/src/pages/purchase/PurchasePage.jsx
@@ -49,12 +49,14 @@ const PurchasePage = () => {
             </PurchaseResult>
           )}
           <PurchaseSeries>
-            <Image
-              alt="시리즈썸네일"
-              width="30%"
-              height="30%"
-              src={values.thumbnail}
-            />
+            <ImageCover>
+              <Image
+                alt="시리즈썸네일"
+                width="100%"
+                height="auto"
+                src={values.thumbnail}
+              />
+            </ImageCover>
             <Content>
               <TitleContainer>
                 <H2>{values.title}</H2>
@@ -129,13 +131,30 @@ const PurchaseSeries = styled.div`
   display: flex;
   width: 100%;
   margin: 1rem 0;
+  @media ${theme.device.tablet} {
+    flex-direction: column;
+    align-items: center;
+  }
+`;
+
+const ImageCover = styled.div`
+  width: 30%;
+  margin: 1rem 0;
+  @media ${theme.device.tablet} {
+    width: 100%;
+  }
+  @media ${theme.device.mobile} {
+    width: 100%;
+  }
 `;
 
 const Content = styled.div`
   width: 100%;
   padding: 0 0.5rem;
   margin-left: 1.25rem;
-
+  @media ${theme.device.tablet} {
+    margin-left: 0;
+  }
   div {
     margin-bottom: 1rem;
   }
@@ -146,6 +165,18 @@ const TitleContainer = styled.div`
   display: flex;
   justify-content: space-between;
   margin: 1rem 0;
+  @media ${theme.device.tablet} {
+    flex-direction: column;
+  }
+  & > h2 {
+    @media ${theme.device.tablet} {
+      margin-bottom: 1rem;
+    }
+    @media ${theme.device.mobile} {
+      font-size: ${theme.font.large};
+      line-height: 2.1rem;
+    }
+  }
 `;
 
 const FlexContainer = styled.div`

--- a/src/pages/user/MyInfoPage.jsx
+++ b/src/pages/user/MyInfoPage.jsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { Wrapper, Container, Button } from '@components';
 import { Link, useHistory } from 'react-router-dom';
 import { useUser } from '@contexts/UserProvider';
+import theme from '@styles/theme';
 
 const MyInfoPage = () => {
   const history = useHistory();
@@ -16,19 +17,41 @@ const MyInfoPage = () => {
 
   return (
     <Wrapper center>
-      <Container title="마이 페이지">
-        <StyledLink to="/my/edit">내 정보 수정</StyledLink>
-        <StyledLink to="/purchase/info">내 구독 내역</StyledLink>
-        <StyledLink to="/my/likes">내 관심 목록</StyledLink>
+      <StyledContainer title="마이 페이지">
+        <LinkList>
+          <StyledLink to="/my/edit">내 정보 수정</StyledLink>
+          <StyledLink to="/purchase/info">내 구독 내역</StyledLink>
+          <StyledLink to="/my/likes">내 관심 목록</StyledLink>
+        </LinkList>
         <StyledButton type="button" onClick={handleClick}>
           로그아웃
         </StyledButton>
-      </Container>
+      </StyledContainer>
     </Wrapper>
   );
 };
 
 export default MyInfoPage;
+
+const StyledContainer = styled(Container)`
+  @media ${theme.device.tablete} {
+    height: 50vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+`;
+
+const LinkList = styled.div`
+  @media ${theme.device.tablete} {
+    flex-grow: 1;
+    align-self: flex-start;
+    margin-top: 2rem;
+  }
+  @media ${theme.device.mobile} {
+    margin-top: 0;
+  }
+`;
 
 const StyledLink = styled(Link)`
   width: 100%;
@@ -40,9 +63,15 @@ const StyledLink = styled(Link)`
   align-items: center;
   padding: 1rem;
   box-shadow: 0 0.25rem 0.25rem -0.25rem #f5f5f5;
+  @media ${theme.device.tablete} {
+    justify-content: center;
+  }
 `;
 
 const StyledButton = styled(Button)`
   width: 100%;
   margin-top: 3rem;
+  @media ${theme.device.tablete} {
+    margin-top: 1rem;
+  }
 `;

--- a/src/pages/user/MyInfoPage.jsx
+++ b/src/pages/user/MyInfoPage.jsx
@@ -34,7 +34,7 @@ const MyInfoPage = () => {
 export default MyInfoPage;
 
 const StyledContainer = styled(Container)`
-  @media ${theme.device.tablete} {
+  @media ${theme.device.tablet} {
     height: 50vh;
     display: flex;
     flex-direction: column;
@@ -43,10 +43,10 @@ const StyledContainer = styled(Container)`
 `;
 
 const LinkList = styled.div`
-  @media ${theme.device.tablete} {
+  @media ${theme.device.tablet} {
     flex-grow: 1;
     align-self: flex-start;
-    margin-top: 2rem;
+    margin-top: 0;
   }
   @media ${theme.device.mobile} {
     margin-top: 0;
@@ -63,7 +63,7 @@ const StyledLink = styled(Link)`
   align-items: center;
   padding: 1rem;
   box-shadow: 0 0.25rem 0.25rem -0.25rem #f5f5f5;
-  @media ${theme.device.tablete} {
+  @media ${theme.device.tablet} {
     justify-content: center;
   }
 `;
@@ -71,7 +71,7 @@ const StyledLink = styled(Link)`
 const StyledButton = styled(Button)`
   width: 100%;
   margin-top: 3rem;
-  @media ${theme.device.tablete} {
+  @media ${theme.device.tablet} {
     margin-top: 1rem;
   }
 `;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.

결제 페이지, 마이페이지, 관련 컴포넌트 
반응형 적용

## 📝 Results
<img src='https://user-images.githubusercontent.com/81611808/149280728-ff709d8c-253e-4bbd-b541-24a341c8c70b.png' width='50%'>
<img src='https://user-images.githubusercontent.com/81611808/149280797-654f198a-b10d-429a-9dac-89cda26c14ca.png' width='50%'>


## 📝 논의점

> breakepoint를 더 컴팩트하게 사용하는 방법에 대해 좀 찾아봐야할 것 같습니다. 지금 상태론 768까지 mobile에 포함되네요 ㅠ
