### PR TITLE
refactor: [MON-270] 홈, 시리즈, 채널 반응형 적용

### DIFF
--- a/src/components/commons/NoData/index.jsx
+++ b/src/components/commons/NoData/index.jsx
@@ -33,4 +33,5 @@ const Container = styled.div`
   align-items: center;
   color: ${theme.color.greyDark};
   background-color: ${({ backgroundColor }) => backgroundColor};
+  padding: 1.25rem;
 `;

--- a/src/components/commons/Wrapper/index.jsx
+++ b/src/components/commons/Wrapper/index.jsx
@@ -31,7 +31,6 @@ export default Wrapper;
 const StyledDiv = styled.div`
   height: auto;
   max-width: ${props => props.width || '71.25rem'};
-  margin: 0 auto;
   padding: 3rem 0;
   margin: 5rem auto 0;
   ${({ center }) =>
@@ -47,6 +46,6 @@ const StyledDiv = styled.div`
   }
   @media ${theme.device.mobile} {
     max-width: 100%;
-    padding: 3rem 1rem;
+    padding: 2rem 1rem;
   }
 `;

--- a/src/components/domain/ArticleList/index.jsx
+++ b/src/components/domain/ArticleList/index.jsx
@@ -40,9 +40,7 @@ ArticleList.propTypes = {
 
 export default ArticleList;
 
-const ArticleListContainer = styled.div`
-  min-height: 20vh;
-`;
+const ArticleListContainer = styled.div``;
 
 const Article = styled.div`
   width: 100%;
@@ -75,13 +73,3 @@ const Article = styled.div`
     }
   }
 `;
-
-// const NoArticle = styled.div`
-//   background-color: ${theme.color.grey};
-//   height: 10rem;
-//   border-radius: 1rem;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   color: ${theme.color.greyDark};
-// `;

--- a/src/components/domain/Card/index.jsx
+++ b/src/components/domain/Card/index.jsx
@@ -88,25 +88,62 @@ Card.propTypes = {
 
 export default Card;
 
-const margin = '1.25rem';
-const contentsMaxCount = 4;
+const { margin, maxWidth, maxCount } = theme.standardValues.card;
+
 const Container = styled.div`
-  width: calc(
-    (100% - (${margin} * ${contentsMaxCount - 1})) / ${contentsMaxCount}
-  );
   margin-right: ${margin};
   margin-top: 2.5rem;
   display: flex;
   flex-direction: column;
   box-shadow: 0 0.2rem 0.625rem 0 rgba(50, 50, 93, 0.2);
-  // border: 1px solid #ccd3e2;
+  max-width: ${maxWidth};
 
-  &:nth-of-type(-n + 4) {
-    margin-top: 0;
+  @media ${theme.device.laptop} {
+    width: calc((100% - (${margin} * ${maxCount.top - 1})) / ${maxCount.top});
+
+    &:nth-of-type(-n + ${maxCount.top}) {
+      margin-top: 0;
+    }
+
+    &:nth-of-type(${maxCount.top}n) {
+      margin-right: 0;
+    }
   }
 
-  &:nth-of-type(${contentsMaxCount}n) {
-    margin-right: 0;
+  @media ${theme.detailedMobile.tablet} {
+    width: calc((100% - (${margin} * ${maxCount.tab - 1})) / ${maxCount.tab});
+
+    &:nth-of-type(-n + ${maxCount.tab}) {
+      margin-top: 0;
+    }
+
+    &:nth-of-type(${maxCount.tab}n) {
+      margin-right: 0;
+    }
+  }
+
+  @media ${theme.detailedMobile.mobileL} {
+    width: calc((100% - (${margin} * ${maxCount.mobL - 1})) / ${maxCount.mobL});
+
+    &:nth-of-type(-n + ${maxCount.mobL}) {
+      margin-top: 0;
+    }
+
+    &:nth-of-type(${maxCount.mobL}n) {
+      margin-right: 0;
+    }
+  }
+
+  @media ${theme.detailedMobile.mobileS} {
+    width: calc((100% - (${margin} * ${maxCount.mobS - 1})) / ${maxCount.mobS});
+
+    &:nth-of-type(-n + ${maxCount.mobS}) {
+      margin-top: 0;
+    }
+
+    &:nth-of-type(${maxCount.mobS}n) {
+      margin-right: 0;
+    }
   }
 `;
 
@@ -114,6 +151,10 @@ const CardImageArea = styled.div`
   height: 11rem;
   background-color: ${theme.color.grey};
   position: relative;
+
+  > a > img {
+    object-fit: cover;
+  }
 `;
 
 const CardStatusTag = styled.div`
@@ -160,7 +201,7 @@ const TextMain = styled.div`
   .intro {
     line-height: 1rem;
     height: 2.2rem;
-    max-height: 2.2rem;
+    max-height: 2rem;
     overflow: hidden;
     text-overflow: ellipsis;
     display: -webkit-box;

--- a/src/components/domain/Card/index.jsx
+++ b/src/components/domain/Card/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import convertCategory from '@utils/convertCategory';
 import { LikeToggle, Image } from '@components';
-import { theme, standardValues } from '@styles';
+import { theme, constants } from '@styles';
 
 const Card = ({ data, ...props }) => (
   <Container {...props}>
@@ -88,7 +88,7 @@ Card.propTypes = {
 
 export default Card;
 
-const { margin, maxWidth, maxCount } = standardValues.card;
+const { margin, maxWidth, maxCount } = constants.card;
 
 const Container = styled.div`
   margin-right: ${margin};

--- a/src/components/domain/Card/index.jsx
+++ b/src/components/domain/Card/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import convertCategory from '@utils/convertCategory';
 import { LikeToggle, Image } from '@components';
-import theme from '@styles/theme';
+import { theme, standardValues } from '@styles';
 
 const Card = ({ data, ...props }) => (
   <Container {...props}>
@@ -88,7 +88,7 @@ Card.propTypes = {
 
 export default Card;
 
-const { margin, maxWidth, maxCount } = theme.standardValues.card;
+const { margin, maxWidth, maxCount } = standardValues.card;
 
 const Container = styled.div`
   margin-right: ${margin};

--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Card, NoData } from '@components';
-import theme from '@styles/theme';
+import { theme, standardValues } from '@styles';
 
 const CardList = ({ list, ...props }) => (
   <CardContainer hasContent={list.length} {...props}>
@@ -24,7 +24,7 @@ CardList.propTypes = {
 
 export default CardList;
 
-const { maxWidth, margin, maxCount } = theme.standardValues.card;
+const { maxWidth, margin, maxCount } = standardValues.card;
 const CardContainer = styled.div`
   width: 100%;
   height: auto;

--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Card, NoData } from '@components';
+import theme from '@styles/theme';
 
 const CardList = ({ list, ...props }) => (
   <CardContainer hasContent={list.length} {...props}>
@@ -23,11 +24,26 @@ CardList.propTypes = {
 
 export default CardList;
 
+const { maxWidth, margin, maxCount } = theme.standardValues.card;
 const CardContainer = styled.div`
   width: 100%;
   height: auto;
-  min-height: 20vh;
   display: flex;
-  align-items: center;
   flex-flow: row wrap;
+  margin: 0 auto;
+
+  @media ${theme.device.laptop} {
+    max-width: 100%;
+  }
+  @media ${theme.detailedMobile.tablet} {
+    max-width: calc(
+      (${maxWidth} * ${maxCount.tab}) + (${margin} * ${maxCount.tab - 1})
+    );
+  }
+  @media ${theme.detailedMobile.mobileL} {
+    max-width: calc((${maxWidth} * ${maxCount.mobL}) + ${margin});
+  }
+  @media ${theme.detailedMobile.mobileS} {
+    max-width: ${maxWidth};
+  }
 `;

--- a/src/components/domain/CardList/index.jsx
+++ b/src/components/domain/CardList/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Card, NoData } from '@components';
-import { theme, standardValues } from '@styles';
+import { theme, constants } from '@styles';
 
 const CardList = ({ list, ...props }) => (
   <CardContainer hasContent={list.length} {...props}>
@@ -24,7 +24,7 @@ CardList.propTypes = {
 
 export default CardList;
 
-const { maxWidth, margin, maxCount } = standardValues.card;
+const { maxWidth, margin, maxCount } = constants.card;
 const CardContainer = styled.div`
   width: 100%;
   height: auto;

--- a/src/components/domain/CardSlider/index.jsx
+++ b/src/components/domain/CardSlider/index.jsx
@@ -13,6 +13,10 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, parentOf }) => {
   const newList = [];
   const slideFullRef = useRef(null);
 
+  if (list.length > 0) {
+    // console.log(itemsCountOnRow);
+  }
+
   const divideList = () => {
     for (let i = 0; i <= list.length; i += 1) {
       if (i === 0 || i % howManyItemsAre === 0) {
@@ -28,6 +32,7 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, parentOf }) => {
     for (let i = 0; i <= lastSlideIndex; i += 1) {
       result.push(
         <SlideSectionArea
+          id={`slide-${i + 1}`}
           key={`slide-${i}`}
           ref={el => {
             slideRef.current[i] = el;
@@ -92,7 +97,7 @@ const CardSlider = ({ list, itemsCountOnRow, itemsCountOnCol, parentOf }) => {
 CardSlider.defaultProps = {
   list: [],
   itemsCountOnRow: 4,
-  itemsCountOnCol: 2,
+  itemsCountOnCol: 1,
   parentOf: '',
 };
 

--- a/src/components/domain/CheckedButtonList/index.jsx
+++ b/src/components/domain/CheckedButtonList/index.jsx
@@ -1,0 +1,189 @@
+import React, { useRef } from 'react';
+import styled from '@emotion/styled';
+import PropTypes from 'prop-types';
+import { theme, mixin } from '@styles';
+
+/*
+ primaryKey: 한 페이지 내에서 두 번 이상의 호출 시 정상적인 작동을 위해
+  id를 구분 할 필요가 있다.
+  ex) 1페이지의 1카테고리 리스트(6개): id = checkedBtn1-1~6
+  ex) 1페이지의 2카테고리 리스트(3개): id = checkedBtn2-1~3
+ */
+const CheckedButtonList = ({
+  list,
+  type,
+  primaryKey,
+  useReverse,
+  onChange,
+  reverseIndex,
+  unDefaultChecked,
+  frameOnly,
+  ...props
+}) => {
+  const checkedRef = useRef([]);
+  const checkedCount = useRef(0);
+  const formRef = useRef();
+
+  // 반전 기능은 다중 선택일 때만 필요하므로 type이 radio일 땐 사용되지 않는다.
+  const reverseChecked = e => {
+    const { value, checked } = e.target;
+
+    if (value === list[reverseIndex].value) {
+      checkedCount.current = 0;
+
+      for (let i = 0; i < checkedRef.current.length; i += 1) {
+        if (i === reverseIndex) {
+          checkedRef.current[i].checked = true;
+          checkedRef.current[i].disabled = true;
+        } else {
+          checkedRef.current[i].checked = false;
+        }
+      }
+    } else if (value !== list[reverseIndex].value) {
+      if (checked) {
+        if (checkedCount.current === 0) {
+          checkedRef.current[reverseIndex].checked = false;
+          checkedRef.current[reverseIndex].disabled = false;
+        }
+
+        checkedCount.current += 1;
+      } else {
+        checkedCount.current -= 1;
+
+        if (checkedCount.current === 0) {
+          checkedRef.current[reverseIndex].checked = true;
+          checkedRef.current[reverseIndex].disabled = true;
+        }
+      }
+    }
+  };
+
+  return (
+    <StyledForm
+      onChange={e => {
+        onChange(e);
+        type === 'checkbox' && useReverse ? reverseChecked(e) : null;
+      }}
+      ref={formRef.current}
+      {...props}
+    >
+      {list.map((data, index) => (
+        <StyledSpan
+          key={data.text}
+          primaryKey={primaryKey}
+          length={list.length}
+          frameOnly={frameOnly}
+        >
+          <input
+            type={type}
+            name={`checkedBtns${primaryKey}`}
+            id={`checkedBtn${primaryKey}-${index}`}
+            value={data.value}
+            ref={el => {
+              checkedRef.current[index] = el;
+            }}
+            {...(useReverse && !unDefaultChecked && index === reverseIndex
+              ? type === 'checkbox'
+                ? { disabled: true, defaultChecked: true }
+                : { defaultChecked: true }
+              : null)}
+          />
+          <label
+            htmlFor={`checkedBtn${primaryKey}-${index}`}
+            className={`styledTag${primaryKey}-${index}`}
+          >
+            {data.text}
+          </label>
+        </StyledSpan>
+      ))}
+    </StyledForm>
+  );
+};
+
+CheckedButtonList.defaultProps = {
+  list: [],
+  type: 'checkbox',
+  primaryKey: 0,
+  useReverse: true,
+  reverseIndex: 0,
+  unDefaultChecked: false,
+  frameOnly: false,
+  onChange: () => {},
+};
+
+CheckedButtonList.propTypes = {
+  list: PropTypes.array,
+  type: PropTypes.string,
+  primaryKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  useReverse: PropTypes.bool,
+  reverseIndex: PropTypes.number,
+  unDefaultChecked: PropTypes.bool,
+  frameOnly: PropTypes.bool,
+  onChange: PropTypes.func,
+};
+
+export default CheckedButtonList;
+
+const setCheckedStyle = (primaryKey, length) => {
+  let styles = '';
+
+  for (let i = 0; i < length; i += 1) {
+    styles += `#checkedBtn${primaryKey}-${i}:checked ~ .styledTag${primaryKey}-${i} {
+      background-color: ${theme.color.sub};
+      color: #ffffff;
+    }`;
+  }
+
+  return styles;
+};
+
+const StyledForm = styled.form`
+  display: flex;
+  width: 100%;
+  overflow-x: scroll;
+  ${mixin.invisibleScrollBar}
+`;
+
+const StyledSpan = styled.span`
+  ${({ frameOnly, primaryKey, length }) =>
+    frameOnly
+      ? `
+      margin: 0.625rem;
+      margin-left: 0;
+      display: flex;
+      align-items: center;
+      > input {
+        width: 1.25rem;
+        height: 1.25rem;
+      }
+      > label {
+        margin-left: 0.1875rem;
+      }
+      `
+      : `
+      height: 2.5rem;
+      margin: 1rem;
+      margin-top: 0;
+      margin-left: 0;
+
+      > label {
+        border-radius: 2.5rem;
+        background-color: #ffffff;
+        box-shadow: ${theme.style.boxShadow};
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        width: 100%;
+        height: 100%;
+        padding: 0 1.25rem;
+        white-space: nowrap;
+        cursor: pointer;
+        overflow: hidden;
+      }
+
+      > input {
+        display: none;
+      }
+      ${setCheckedStyle(primaryKey, length)}
+  `}
+`;

--- a/src/components/domain/CheckedButtonList/index.jsx
+++ b/src/components/domain/CheckedButtonList/index.jsx
@@ -3,12 +3,6 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { theme, mixin } from '@styles';
 
-/*
- primaryKey: 한 페이지 내에서 두 번 이상의 호출 시 정상적인 작동을 위해
-  id를 구분 할 필요가 있다.
-  ex) 1페이지의 1카테고리 리스트(6개): id = checkedBtn1-1~6
-  ex) 1페이지의 2카테고리 리스트(3개): id = checkedBtn2-1~3
- */
 const CheckedButtonList = ({
   list,
   type,
@@ -24,7 +18,6 @@ const CheckedButtonList = ({
   const checkedCount = useRef(0);
   const formRef = useRef();
 
-  // 반전 기능은 다중 선택일 때만 필요하므로 type이 radio일 땐 사용되지 않는다.
   const reverseChecked = e => {
     const { value, checked } = e.target;
 

--- a/src/components/domain/HottestList/index.jsx
+++ b/src/components/domain/HottestList/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import { theme, standardValues } from '@styles';
+import { theme, constants } from '@styles';
 import { NoData } from '@components';
 
 const HottestList = ({ list, ...props }) => (
@@ -36,7 +36,7 @@ HottestList.propTypes = {
 
 export default HottestList;
 
-const { top, tab, mobL, mobS } = standardValues.banner.maxCount;
+const { top, tab, mobL, mobS } = constants.banner.maxCount;
 
 const ListCardContainer = styled.div`
   width: 100%;

--- a/src/components/domain/HottestList/index.jsx
+++ b/src/components/domain/HottestList/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
-import theme from '@styles/theme';
+import { theme, standardValues } from '@styles';
 import { NoData } from '@components';
 
 const HottestList = ({ list, ...props }) => (
@@ -36,7 +36,7 @@ HottestList.propTypes = {
 
 export default HottestList;
 
-const { top, tab, mobL, mobS } = theme.standardValues.banner.maxCount;
+const { top, tab, mobL, mobS } = standardValues.banner.maxCount;
 
 const ListCardContainer = styled.div`
   width: 100%;

--- a/src/components/domain/HottestList/index.jsx
+++ b/src/components/domain/HottestList/index.jsx
@@ -36,6 +36,8 @@ HottestList.propTypes = {
 
 export default HottestList;
 
+const { top, tab, mobL, mobS } = theme.standardValues.banner.maxCount;
+
 const ListCardContainer = styled.div`
   width: 100%;
   height: auto;
@@ -48,9 +50,24 @@ const ListCardContainer = styled.div`
 `;
 
 const CardContainer = styled.div`
-  width: 20%;
   height: 30rem;
   position: relative;
+
+  @media ${theme.device.laptop} {
+    width: calc(100% / ${top});
+  }
+
+  @media ${theme.detailedMobile.tablet} {
+    width: calc(100% / ${tab});
+  }
+
+  @media ${theme.detailedMobile.mobileL} {
+    width: calc(100% / ${mobL});
+  }
+
+  @media ${theme.detailedMobile.mobileS} {
+    width: calc(100% / ${mobS});
+  }
 `;
 
 const HottestImage = styled.img`

--- a/src/components/domain/UserList/index.jsx
+++ b/src/components/domain/UserList/index.jsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Button, SectionContainer, UserProfile, NoData } from '@components';
-import { mixin, standardValues } from '@styles';
+import { mixin, constants } from '@styles';
 
 const UserList = ({ list, title, moreLink, ...props }) => {
-  const { maxCount, size } = standardValues.userList;
+  const { maxCount, size } = constants.userList;
 
   return (
     <SectionContainer

--- a/src/components/domain/UserList/index.jsx
+++ b/src/components/domain/UserList/index.jsx
@@ -3,43 +3,50 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Button, SectionContainer, UserProfile, NoData } from '@components';
+import { theme, mixin } from '@styles';
 
-const UserList = ({ list, title, moreLink, ...props }) => (
-  <SectionContainer
-    {...props}
-    title={title}
-    titleItem={
-      <div className="seeMore">
-        {moreLink ? (
-          list.length === 10 ? (
-            <Link to={moreLink}>
-              <Button margin={0} width="6.25rem" height="1.875rem">
-                더보기
-              </Button>
-            </Link>
-          ) : null
-        ) : null}
-      </div>
-    }
-  >
-    <UserListBody>
-      {list.length ? (
-        list.map(item => (
-          <StyledUserProfile
-            src={item.profileImage}
-            size={5}
-            userId={item.userId}
-            nickname={item.nickname}
-            key={item.userId}
-            isSubscribeable={item.subscribeStatus === 'SUBSCRIPTION_AVAILABLE'}
-          />
-        ))
-      ) : (
-        <NoData>유저 데이터가 존재하지 않습니다</NoData>
-      )}
-    </UserListBody>
-  </SectionContainer>
-);
+const UserList = ({ list, title, moreLink, ...props }) => {
+  const { maxCount, size } = theme.standardValues.userList;
+
+  return (
+    <SectionContainer
+      {...props}
+      title={title}
+      titleItem={
+        <div className="seeMore">
+          {moreLink ? (
+            list.length === maxCount ? (
+              <Link to={moreLink}>
+                <Button margin={0} width="6.25rem" height="1.875rem">
+                  더보기
+                </Button>
+              </Link>
+            ) : null
+          ) : null}
+        </div>
+      }
+    >
+      <UserListBody>
+        {list.length ? (
+          list.map(item => (
+            <StyledUserProfile
+              src={item.profileImage}
+              size={size}
+              userId={item.userId}
+              nickname={item.nickname}
+              key={item.userId}
+              isSubscribeable={
+                item.subscribeStatus === 'SUBSCRIPTION_AVAILABLE'
+              }
+            />
+          ))
+        ) : (
+          <NoData>유저 데이터가 존재하지 않습니다</NoData>
+        )}
+      </UserListBody>
+    </SectionContainer>
+  );
+};
 
 UserList.defaultProps = {
   list: [],
@@ -57,10 +64,15 @@ export default UserList;
 
 const UserListBody = styled.div`
   display: flex;
-  align-items: center;
-  min-height: 6.75rem;
+  overflow: hidden;
+  overflow-x: scroll;
+  padding-bottom: 1.25rem;
+  ${mixin.invisibleScrollBar};
 `;
 
 const StyledUserProfile = styled(UserProfile)`
-  margin-right: 1.75rem;
+  padding-right: 2.3606875rem;
+  &:last-of-type {
+    padding-right: 0;
+  }
 `;

--- a/src/components/domain/UserList/index.jsx
+++ b/src/components/domain/UserList/index.jsx
@@ -3,10 +3,10 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import { Button, SectionContainer, UserProfile, NoData } from '@components';
-import { theme, mixin } from '@styles';
+import { mixin, standardValues } from '@styles';
 
 const UserList = ({ list, title, moreLink, ...props }) => {
-  const { maxCount, size } = theme.standardValues.userList;
+  const { maxCount, size } = standardValues.userList;
 
   return (
     <SectionContainer

--- a/src/components/domain/UserProfile/index.jsx
+++ b/src/components/domain/UserProfile/index.jsx
@@ -46,14 +46,12 @@ UserProfile.propTypes = {
 
 export default UserProfile;
 
-const ProfileContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-`;
+const ProfileContainer = styled.div``;
 
 const Nickname = styled.span`
+  display: inline-block;
+  width: 100%;
+  text-align: center;
   font-size: ${({ fontSize }) =>
     typeof fontSize === 'number' ? `${fontSize}rem` : fontSize};
   margin-top: 0.75rem;
@@ -62,9 +60,6 @@ const Nickname = styled.span`
 const ProfileWrapper = styled.div`
   width: ${({ size }) => (typeof size === 'number' ? `${size}rem` : size)};
   height: ${({ size }) => (typeof size === 'number' ? `${size}rem` : size)};
-  display: flex;
-  align-items: center;
-  justify-content: center;
   border-radius: ${({ size }) =>
     typeof size === 'number' ? `${size}rem` : size};
   overflow: hidden;

--- a/src/components/index.jsx
+++ b/src/components/index.jsx
@@ -34,3 +34,4 @@ export { default as ArticleForm } from './domain/ArticleForm';
 export { default as ButtonSelect } from './domain/SelectInput/ButtonSelect';
 export { default as DropListSelect } from './domain/SelectInput/DropListSelect';
 export { default as NoData } from './commons/NoData';
+export { default as CheckedButtonList } from './domain/CheckedButtonList';

--- a/src/index.css
+++ b/src/index.css
@@ -22,6 +22,7 @@ html {
 body {
   font-family: 'Eulyoo1945', serif;
   overflow-y: scroll;
+  overflow-x: hidden;
   background-color: #f2f2f2;
 }
 

--- a/src/pages/channel/ChannelPage.jsx
+++ b/src/pages/channel/ChannelPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { theme, mixin, standardValues } from '@styles';
+import { theme, mixin, constants } from '@styles';
 import {
   Wrapper,
   SectionContainer,
@@ -128,7 +128,7 @@ const ChannelPage = () => {
   const isTablet = useMediaQuery(theme.detailedMobile.tablet);
   const isMobile = useMediaQuery(theme.detailedMobile.mobileS);
   const isMobileS = useMediaQuery(theme.detailedMobile.mobileL);
-  const { maxCount } = standardValues.card;
+  const { maxCount } = constants.card;
 
   const callSlide = getList => (
     <CardSlider

--- a/src/pages/channel/ChannelPage.jsx
+++ b/src/pages/channel/ChannelPage.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
-import { theme, mixin } from '@styles';
+import { theme, mixin, standardValues } from '@styles';
 import {
   Wrapper,
   SectionContainer,
@@ -128,7 +128,7 @@ const ChannelPage = () => {
   const isTablet = useMediaQuery(theme.detailedMobile.tablet);
   const isMobile = useMediaQuery(theme.detailedMobile.mobileS);
   const isMobileS = useMediaQuery(theme.detailedMobile.mobileL);
-  const { maxCount } = theme.standardValues.card;
+  const { maxCount } = standardValues.card;
 
   const callSlide = getList => (
     <CardSlider

--- a/src/pages/channel/ChannelPage.jsx
+++ b/src/pages/channel/ChannelPage.jsx
@@ -13,6 +13,7 @@ import {
 import { getMyChannel, getChannel } from '@apis/channel';
 import { useParams, useHistory } from 'react-router-dom';
 import { postFollow, deleteFollow } from '@apis/follow';
+import { useMediaQuery } from '@material-ui/core';
 import cover from './channel_cover.jpg';
 
 const initialData = {
@@ -103,6 +104,7 @@ const ChannelPage = () => {
         setData(data);
       }
     }
+    setLoading(false);
   };
 
   const handleClick = () => {
@@ -116,8 +118,33 @@ const ChannelPage = () => {
 
   useEffect(() => {
     getInitialData();
-    setLoading(false);
-  }, [id, data.isFollowed]);
+  }, [id]);
+
+  useEffect(() => {
+    getInitialData();
+  }, [data.isFollowed]);
+
+  const isLaptop = useMediaQuery(theme.device.laptop);
+  const isTablet = useMediaQuery(theme.detailedMobile.tablet);
+  const isMobile = useMediaQuery(theme.detailedMobile.mobileS);
+  const isMobileS = useMediaQuery(theme.detailedMobile.mobileL);
+  const { maxCount } = theme.standardValues.card;
+
+  const callSlide = getList => (
+    <CardSlider
+      list={getList}
+      itemsCountOnRow={
+        isMobileS
+          ? maxCount.mobS
+          : isMobile
+          ? maxCount.mobL
+          : isTablet
+          ? maxCount.tab
+          : maxCount.top
+      }
+      itemsCountOnCol={isLaptop ? 2 : isTablet ? 2 : 1}
+    />
+  );
 
   return (
     <Wrapper>
@@ -181,7 +208,7 @@ const ChannelPage = () => {
           {!id ? (
             data.subscribeList.length > 0 ? (
               <SectionContainer title="구독한 시리즈">
-                <CardSlider list={data.subscribeList} />
+                {callSlide(data.subscribeList)}
               </SectionContainer>
             ) : (
               <SectionContainer title="구독한 시리즈">
@@ -193,7 +220,7 @@ const ChannelPage = () => {
           ) : null}
           {data.seriesPostList.length > 0 ? (
             <SectionContainer title="작성한 시리즈">
-              <CardSlider list={data.seriesPostList} />
+              {callSlide(data.seriesPostList)}
             </SectionContainer>
           ) : !id ? (
             <SectionContainer title="작성한 시리즈">
@@ -217,13 +244,12 @@ const ProfileWrapper = styled.div`
   height: ${ProfileAreaHeight};
   background-image: url(${cover});
   background-repeat: no-repeat;
-  background-size: 100% auto;
+  background-size: cover;
   display: flex;
   flex-direction: column;
 `;
 
 const ProfileContainer = styled.div`
-  width: 71.25rem;
   height: 100%;
   margin: 0 auto;
   display: flex;
@@ -238,18 +264,18 @@ const UserInfo = styled.div`
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  margin-bottom: 20px;
+  margin-bottom: 1.25rem;
 
   .nickname {
-    font-size: 32px;
+    font-size: 2rem;
     font-weight: bold;
-    margin-top: 20px;
-    margin-bottom: 10px;
+    margin-top: 1.25rem;
+    margin-bottom: 0.625rem;
   }
 
   .intro {
     max-width: 70%;
-    height: 80px;
+    height: 5rem;
     line-height: 1rem;
   }
 `;
@@ -259,7 +285,7 @@ const ProfileMain = styled.div`
 `;
 
 const ProfileBottom = styled.div`
-  height: 50px;
+  height: 3.125rem;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -268,7 +294,7 @@ const ProfileBottom = styled.div`
   background: rgba(0, 0, 0, 0.1);
 
   > div {
-    margin-right: 20px;
+    margin-right: 1.25rem;
   }
   > div:last-of-type {
     margin-right: 0;
@@ -276,9 +302,9 @@ const ProfileBottom = styled.div`
 `;
 
 const StyledButton = styled(`button`)`
-  height: 30px;
-  width: 90px;
-  border-radius: 30px;
+  height: 1.875rem;
+  width: 5.625rem;
+  border-radius: 1.875rem;
   border: 0.13rem solid #5cb85c;
   background-color: ${({ bgColor }) => bgColor};
   color: ${({ isFollowed }) => (isFollowed ? '#5cb85c' : `#fff`)};

--- a/src/pages/general/HomePage.jsx
+++ b/src/pages/general/HomePage.jsx
@@ -12,7 +12,7 @@ import { getMyPurchaseSeries } from '@apis/user';
 import { getPopularWriters } from '@apis/auth';
 import { getPopularSeries, getRecentSeries } from '@apis/series';
 import { useMediaQuery } from '@material-ui/core';
-import theme from '@styles/theme';
+import { theme, standardValues } from '@styles';
 
 const HomePage = () => {
   const [loading, setLoading] = useState(true);
@@ -64,7 +64,7 @@ const HomePage = () => {
   const isTablet = useMediaQuery(theme.detailedMobile.tablet);
   const isMobile = useMediaQuery(theme.detailedMobile.mobileL);
   const isMobileS = useMediaQuery(theme.detailedMobile.mobileS);
-  const { maxCount } = theme.standardValues.banner;
+  const { maxCount } = standardValues.banner;
 
   return (
     <HomepageContainer>

--- a/src/pages/general/HomePage.jsx
+++ b/src/pages/general/HomePage.jsx
@@ -12,7 +12,7 @@ import { getMyPurchaseSeries } from '@apis/user';
 import { getPopularWriters } from '@apis/auth';
 import { getPopularSeries, getRecentSeries } from '@apis/series';
 import { useMediaQuery } from '@material-ui/core';
-import { theme, standardValues } from '@styles';
+import { theme, constants } from '@styles';
 
 const HomePage = () => {
   const [loading, setLoading] = useState(true);
@@ -64,7 +64,7 @@ const HomePage = () => {
   const isTablet = useMediaQuery(theme.detailedMobile.tablet);
   const isMobile = useMediaQuery(theme.detailedMobile.mobileL);
   const isMobileS = useMediaQuery(theme.detailedMobile.mobileS);
-  const { maxCount } = standardValues.banner;
+  const { maxCount } = constants.banner;
 
   return (
     <HomepageContainer>

--- a/src/pages/general/HomePage.jsx
+++ b/src/pages/general/HomePage.jsx
@@ -11,6 +11,8 @@ import {
 import { getMyPurchaseSeries } from '@apis/user';
 import { getPopularWriters } from '@apis/auth';
 import { getPopularSeries, getRecentSeries } from '@apis/series';
+import { useMediaQuery } from '@material-ui/core';
+import theme from '@styles/theme';
 
 const HomePage = () => {
   const [loading, setLoading] = useState(true);
@@ -59,6 +61,11 @@ const HomePage = () => {
     getInitialData();
   }, []);
 
+  const isTablet = useMediaQuery(theme.detailedMobile.tablet);
+  const isMobile = useMediaQuery(theme.detailedMobile.mobileL);
+  const isMobileS = useMediaQuery(theme.detailedMobile.mobileS);
+  const { maxCount } = theme.standardValues.banner;
+
   return (
     <HomepageContainer>
       {loading ? (
@@ -68,7 +75,15 @@ const HomePage = () => {
           <CardSlider
             list={values.popularSeriesList}
             parentOf="main"
-            itemsCountOnRow={5}
+            itemsCountOnRow={
+              isMobileS
+                ? maxCount.mobS
+                : isMobile
+                ? maxCount.mobL
+                : isTablet
+                ? maxCount.tab
+                : maxCount.top
+            }
             itemsCountOnCol={1}
           />
           <Wrapper className="customWrapper">

--- a/src/pages/series/SeriesDetailPage.jsx
+++ b/src/pages/series/SeriesDetailPage.jsx
@@ -95,6 +95,54 @@ const SeriesDetailPage = () => {
               height="auto"
             />
           </ImageArea>
+          <InfoArea>
+            <SeriesInfo>
+              <div>작품 정보</div>
+              <SeriesInfoSection>
+                <div className="seriesInfoBlock">
+                  <div>모집일</div>
+                  <div>
+                    {detail.subscribe.startDate} ~ {detail.subscribe.endDate}
+                  </div>
+                </div>
+                <div className="seriesInfoBlock">
+                  <div>구독료</div>
+                  <div>{detail.series.price} 원</div>
+                </div>
+                <div className="seriesInfoBlock">
+                  <div>연재 일</div>
+                  <div>
+                    {detail.series.startDate} ~ {detail.series.endDate}
+                  </div>
+                </div>
+                <div className="seriesInfoBlock">
+                  <div>연재 주기</div>
+                  <div>
+                    {convertDay(detail.upload.date).join(', ')}
+                    &nbsp;{detail.upload.time} 시
+                  </div>
+                </div>
+                <div className="seriesInfoBlock">
+                  <div>총 회차</div>
+                  <div>{detail.series.articleCount} 회</div>
+                </div>
+              </SeriesInfoSection>
+              {sessionStorage.getItem('authorization') && !detail.isMine ? (
+                <Link to={`/purchase/${detail.series.id}`}>
+                  <SeriesInfoSection>
+                    <Button
+                      className="seriesPurchase"
+                      width="100%"
+                      height="2.8125rem"
+                      margin={0}
+                    >
+                      결제하기
+                    </Button>
+                  </SeriesInfoSection>
+                </Link>
+              ) : null}
+            </SeriesInfo>
+          </InfoArea>
           <MainArea>
             <div>
               <DetailForm
@@ -112,53 +160,6 @@ const SeriesDetailPage = () => {
                 isLiked={detail.isLiked}
               />
             </div>
-            <InfoArea>
-              <SeriesInfoHead>INFORMATION</SeriesInfoHead>
-              <SeriesInfo>
-                <SeriesInfoSection>
-                  <div>구독 정보</div>
-                  <div className="seriesInfoBlock">
-                    <div>모집일</div>
-                    {detail.subscribe.startDate} ~ {detail.subscribe.endDate}
-                  </div>
-                  <div className="seriesInfoBlock">
-                    <div>구독료</div>
-                    {detail.series.price} 원
-                  </div>
-                </SeriesInfoSection>
-                <SeriesInfoSection>
-                  <div>연재 정보</div>
-                  <div className="seriesInfoBlock">
-                    <div>연재 일</div>
-                    {detail.series.startDate} ~ {detail.series.endDate}
-                  </div>
-                  <div className="seriesInfoBlock">
-                    <div>연재 주기</div>
-                    {convertDay(detail.upload.date).join(', ')}
-                    &nbsp;{detail.upload.time} 시
-                  </div>
-                  <div className="seriesInfoBlock">
-                    <div>총 회차</div>
-                    {detail.series.articleCount} 회
-                  </div>
-                </SeriesInfoSection>
-                <SeriesInfoSection>
-                  <Link to={`/purchase/${detail.series.id}`}>
-                    {sessionStorage.getItem('authorization') &&
-                    !detail.isMine ? (
-                      <Button
-                        className="seriesPurchase"
-                        width="100%"
-                        height="2.8125rem"
-                        margin={0}
-                      >
-                        결제하기
-                      </Button>
-                    ) : null}
-                  </Link>
-                </SeriesInfoSection>
-              </SeriesInfo>
-            </InfoArea>
           </MainArea>
           <ArticleArea>
             <div className="articleAreaHeader">
@@ -192,10 +193,9 @@ const ImageArea = styled.div`
   overflow: hidden;
 
   > * {
-    position: absolute;
-    top: 50%;
-    left: 0;
-    transform: translateY(-50%);
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
   }
 `;
 
@@ -214,21 +214,7 @@ const MainArea = styled.div`
 `;
 
 const InfoArea = styled.div`
-  border-radius: 1rem 1rem 0 0;
-  box-shadow: ${theme.style.boxShadow};
-  margin-left: 3rem;
-`;
-
-const SeriesInfoHead = styled.div`
-  border-radius: 1rem 1rem 0 0;
-  background-color: orange;
-  height: 3.125rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: #ffffff;
-  font-size: ${theme.font.medium};
-  font-weight: bold;
+  margin-bottom: 2.5rem;
 `;
 
 const SeriesInfo = styled.div`
@@ -236,25 +222,39 @@ const SeriesInfo = styled.div`
   height: auto;
   padding: 2rem 1.5rem;
   background-color: #ffffff;
+  border-radius: 0.625rem;
+  box-shadow: ${theme.style.boxShadow};
+
   > div:nth-of-type(1) {
-    margin-bottom: 2rem;
+    font-weight: 700;
+    font-size: ${theme.font.large};
+    margin-bottom: 1.25rem;
   }
 `;
 
 const SeriesInfoSection = styled.div`
-  > div:nth-of-type(1) {
-    font-weight: bold;
-    font-size: ${theme.font.medium};
-    margin-bottom: 0.5rem;
-  }
+  display: flex;
+  flex-wrap: wrap;
 
   .seriesInfoBlock {
-    margin-top: 1rem;
+    display: flex;
+    padding-left: 0.625rem;
+    margin: 0.125rem 0;
+    margin-right: 0.625rem;
+    border-left: 2px solid ${theme.color.grey};
 
     > div:nth-of-type(1) {
+      margin-right: 0.625rem;
       font-weight: 700;
-      margin: 0 1rem 0.5rem 0;
+      margin-bottom: 0.5rem;
       color: ${theme.color.main};
+    }
+
+    > div:nth-of-type(2) {
+    }
+
+    &:last-of-type {
+      margin-bottom: 0;
     }
   }
 

--- a/src/pages/series/SeriesListPage.jsx
+++ b/src/pages/series/SeriesListPage.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Wrapper, CardList, Loading } from '@components';
+import { Wrapper, CardList, Loading, CheckedButtonList } from '@components';
 import { getSeries } from '@apis/series';
 import { useHistory } from 'react-router-dom';
 import styled from '@emotion/styled';
@@ -40,7 +40,51 @@ const SeriesListPage = () => {
     { key: 'ETC', value: false },
   ]);
 
-  const categoriesRef = useRef([]); // checked속성에 접근하기 위한 용도
+  const ctgrList = [
+    {
+      value: 'ALL',
+      text: '전체',
+    },
+    {
+      value: 'NOVEL',
+      text: '소설',
+    },
+    {
+      value: 'POEM',
+      text: '시',
+    },
+    {
+      value: 'ESSAY',
+      text: '에세이',
+    },
+    {
+      value: 'INTERVIEW',
+      text: '인터뷰',
+    },
+    {
+      value: 'CRITIQUE',
+      text: '평론',
+    },
+    {
+      value: 'ETC',
+      text: '기타',
+    },
+  ];
+
+  const statusList = [
+    {
+      value: '',
+      text: '전체',
+    },
+    {
+      value: 'SERIALIZATION_AVAILABLE',
+      text: '연재중',
+    },
+    {
+      value: 'SUBSCRIPTION_AVAILABLE',
+      text: '모집중',
+    },
+  ];
 
   // 스테이터스
   const [status, setStatus] = useState('');
@@ -51,17 +95,6 @@ const SeriesListPage = () => {
       return false;
     }
     return true;
-  };
-
-  const reverseChecked = () => {
-    for (let i = 0; i < categoriesRef.current.length; i += 1) {
-      if (i === 0) {
-        categoriesRef.current[i].checked = true;
-        categoriesRef.current[i].disabled = true;
-      } else {
-        categoriesRef.current[i].checked = false;
-      }
-    }
   };
 
   const getListUpdate = async () => {
@@ -87,7 +120,6 @@ const SeriesListPage = () => {
 
   const handleCategoriesChange = e => {
     const { value } = e.target;
-    let countChecked = 0;
 
     if (value === 'ALL') {
       setRowCategories([
@@ -98,24 +130,12 @@ const SeriesListPage = () => {
         { key: 'CRITIQUE', value: false },
         { key: 'ETC', value: false },
       ]);
-      reverseChecked();
     } else if (value !== 'ALL') {
-      if (categoriesRef.current[0].checked) {
-        categoriesRef.current[0].checked = false;
-        categoriesRef.current[0].disabled = false;
-      }
-
       setRowCategories(
         rowCategories.map(obj =>
           obj.key === value ? { ...obj, value: !obj.value } : obj,
         ),
       );
-
-      countChecked = categoriesRef.current.filter(el => el.checked).length;
-
-      if (countChecked === 0) {
-        reverseChecked();
-      }
     }
   };
 
@@ -187,79 +207,22 @@ const SeriesListPage = () => {
       ) : (
         <>
           <StyledContainer>
-            <form onChange={handleCategoriesChange}>
-              <input
-                type="checkbox"
-                value="ALL"
-                id="ctgr1"
-                ref={el => {
-                  categoriesRef.current[0] = el;
-                }}
-                defaultChecked
-                disabled
+            <div>
+              <CheckedButtonList
+                list={ctgrList}
+                onChange={handleCategoriesChange}
               />
-              <label htmlFor="ctgr1">전체</label>
-              <input
-                type="checkbox"
-                value="NOVEL"
-                id="ctgr2"
-                ref={el => {
-                  categoriesRef.current[1] = el;
-                }}
+            </div>
+            <div>
+              <CheckedButtonList
+                list={statusList}
+                onChange={handleStatusChange}
+                type="radio"
+                primaryKey={2}
               />
-              <label htmlFor="ctgr2">소설</label>
-              <input
-                type="checkbox"
-                value="POEM"
-                id="ctgr3"
-                ref={el => {
-                  categoriesRef.current[2] = el;
-                }}
-              />
-              <label htmlFor="ctgr3">시</label>
-              <input
-                type="checkbox"
-                value="ESSAY"
-                id="ctgr4"
-                ref={el => {
-                  categoriesRef.current[3] = el;
-                }}
-              />
-              <label htmlFor="ctgr4">에세이</label>
-              <input
-                type="checkbox"
-                value="INTERVIEW"
-                id="ctgr5"
-                ref={el => {
-                  categoriesRef.current[4] = el;
-                }}
-              />
-              <label htmlFor="ctgr5">인터뷰</label>
-              <input
-                type="checkbox"
-                value="CRITIQUE"
-                id="ctgr6"
-                ref={el => {
-                  categoriesRef.current[5] = el;
-                }}
-              />
-              <label htmlFor="ctgr6">평론</label>
-              <input
-                type="checkbox"
-                value="ETC"
-                id="ctgr7"
-                ref={el => {
-                  categoriesRef.current[6] = el;
-                }}
-              />
-              <label htmlFor="ctgr7">기타</label>
-            </form>
-            <select onChange={handleStatusChange}>
-              <option value="">전체</option>
-              <option value="SERIALIZATION_AVAILABLE">연재중</option>
-              <option value="SUBSCRIPTION_AVAILABLE">모집중</option>
-            </select>
+            </div>
           </StyledContainer>
+
           <CardList list={list} />
         </>
       )}
@@ -271,7 +234,5 @@ const SeriesListPage = () => {
 export default SeriesListPage;
 
 const StyledContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
   padding-bottom: 1.25rem;
 `;

--- a/src/pages/series/SeriesListPage.jsx
+++ b/src/pages/series/SeriesListPage.jsx
@@ -5,8 +5,6 @@ import { useHistory } from 'react-router-dom';
 import styled from '@emotion/styled';
 
 const SeriesListPage = () => {
-  // state
-  // 공통
   const size = 16;
   const [list, setList] = useState([]);
   const [params, setParams] = useState({
@@ -23,14 +21,12 @@ const SeriesListPage = () => {
   });
   const requestType = useRef(null);
   const [isLoading, setIsLoading] = useState(true);
-  const history = useHistory(); // 에러페이지
+  const history = useHistory();
 
-  // 무한스크롤
   const [loading, setLoading] = useState(false);
   const setSeriesId = useRef(null);
   const pageEnd = useRef();
 
-  // 카테고라이징
   const [rowCategories, setRowCategories] = useState([
     { key: 'NOVEL', value: false },
     { key: 'POEM', value: false },
@@ -86,10 +82,8 @@ const SeriesListPage = () => {
     },
   ];
 
-  // 스테이터스
   const [status, setStatus] = useState('');
 
-  // Function
   const afterMount = () => {
     if (list.length === 0) {
       return false;
@@ -144,8 +138,6 @@ const SeriesListPage = () => {
     setStatus(value);
   };
 
-  // useEffect
-  // 파라미터
   useEffect(() => {
     getListUpdate();
   }, [params]);
@@ -162,13 +154,11 @@ const SeriesListPage = () => {
     requestType.current = type;
   };
 
-  // 무한스크롤
   useEffect(() => {
     if (loading) {
       const observer = new IntersectionObserver(
         entries => {
           if (entries[0].isIntersecting) {
-            // 현재 lastId와 업데이트 하려는 lastId가 다를 때만 무한스크롤 작동
             currentParams.current['lastSeriesId'] = setSeriesId.current;
             updateParams('scroll');
           }
@@ -179,7 +169,6 @@ const SeriesListPage = () => {
     }
   }, [loading]);
 
-  // 카테고라이징
   useEffect(() => {
     if (afterMount()) {
       let result = '';
@@ -194,7 +183,6 @@ const SeriesListPage = () => {
     }
   }, [rowCategories]);
 
-  // 스테이터스
   useEffect(() => {
     currentParams.current['status'] = status;
     updateParams('status');

--- a/src/styles/constants.jsx
+++ b/src/styles/constants.jsx
@@ -1,4 +1,4 @@
-const standardValues = {
+const constants = {
   card: {
     maxWidth: '330px',
     margin: '20px',
@@ -23,4 +23,4 @@ const standardValues = {
   },
 };
 
-export default standardValues;
+export default constants;

--- a/src/styles/index.jsx
+++ b/src/styles/index.jsx
@@ -1,3 +1,3 @@
 export { default as mixin } from './mixin';
 export { default as theme } from './theme';
-export { default as standardValues } from './standardValues';
+export { default as constants } from './constants';

--- a/src/styles/index.jsx
+++ b/src/styles/index.jsx
@@ -1,2 +1,3 @@
 export { default as mixin } from './mixin';
 export { default as theme } from './theme';
+export { default as standardValues } from './standardValues';

--- a/src/styles/mixin.jsx
+++ b/src/styles/mixin.jsx
@@ -7,6 +7,14 @@ const fullScreen = css`
   margin-left: calc(-50vw + 50%);
 `;
 
-const mixin = { fullScreen };
+const invisibleScrollBar = css`
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+  &::-webkit-scrollbar {
+    display: none; /* Chrome, Safari, Opera*/
+  }
+`;
+
+const mixin = { fullScreen, invisibleScrollBar };
 
 export default mixin;

--- a/src/styles/standardValues.jsx
+++ b/src/styles/standardValues.jsx
@@ -1,0 +1,26 @@
+const standardValues = {
+  card: {
+    maxWidth: '330px',
+    margin: '20px',
+    maxCount: {
+      top: 4,
+      tab: 3,
+      mobL: 2,
+      mobS: 1,
+    },
+  },
+  userList: {
+    maxCount: 10,
+    size: '5rem',
+  },
+  banner: {
+    maxCount: {
+      top: 5,
+      tab: 3,
+      mobL: 2,
+      mobS: 1,
+    },
+  },
+};
+
+export default standardValues;

--- a/src/styles/theme.jsx
+++ b/src/styles/theme.jsx
@@ -48,31 +48,6 @@ const detailedMobile = {
   mobileS: `screen and (max-width: ${deviceSizes.mobile - 0.1}px)`,
 };
 
-const standardValues = {
-  card: {
-    maxWidth: '330px',
-    margin: '20px',
-    maxCount: {
-      top: 4,
-      tab: 3,
-      mobL: 2,
-      mobS: 1,
-    },
-  },
-  userList: {
-    maxCount: 10,
-    size: '5rem',
-  },
-  banner: {
-    maxCount: {
-      top: 5,
-      tab: 3,
-      mobL: 2,
-      mobS: 1,
-    },
-  },
-};
-
 const theme = {
   color,
   font,
@@ -80,7 +55,6 @@ const theme = {
   common,
   device,
   detailedMobile,
-  standardValues,
 };
 
 export default theme;

--- a/src/styles/theme.jsx
+++ b/src/styles/theme.jsx
@@ -26,22 +26,61 @@ const common = {
 };
 
 const deviceSizes = {
-  mobile: '375px',
-  tablet: '768px',
-  laptop: '1024px',
+  mobile: 480,
+  tablet: 768,
+  laptop: 1140,
 };
 
 const device = {
-  mobile: `screen and (max-width: ${deviceSizes.tablet})`,
-  tablet: `screen and (max-width: ${deviceSizes.laptop})`,
+  laptop: `screen and (min-width: ${deviceSizes.laptop}px)`,
+  tablet: `screen and (max-width: ${deviceSizes.laptop - 0.1}px)`,
+  mobile: `screen and (max-width: ${deviceSizes.tablet - 0.1}px)`,
+  mobileS: `screen and (max-width: ${deviceSizes.mobile - 0.1}px)`,
+};
+
+const detailedMobile = {
+  tablet: `screen and (max-width: ${
+    deviceSizes.laptop - 0.1
+  }px) and (min-width: ${deviceSizes.tablet}px)`,
+  mobileL: `screen and (max-width: ${
+    deviceSizes.tablet - 0.1
+  }px) and (min-width: ${deviceSizes.mobile}px)`,
+  mobileS: `screen and (max-width: ${deviceSizes.mobile - 0.1}px)`,
+};
+
+const standardValues = {
+  card: {
+    maxWidth: '330px',
+    margin: '20px',
+    maxCount: {
+      top: 4,
+      tab: 3,
+      mobL: 2,
+      mobS: 1,
+    },
+  },
+  userList: {
+    maxCount: 10,
+    size: '5rem',
+  },
+  banner: {
+    maxCount: {
+      top: 5,
+      tab: 3,
+      mobL: 2,
+      mobS: 1,
+    },
+  },
 };
 
 const theme = {
   color,
   font,
   style,
-  device,
   common,
+  device,
+  detailedMobile,
+  standardValues,
 };
 
 export default theme;


### PR DESCRIPTION
## 📝 Tasks

> 구현한 사항을 자세하게 기재합니다.
###공통사항
- 반응형 구현했습니다.

###theme.jsx
- 계산 값 -1에서 -0.1로 적용했습니다. 1로 하면 웹에서 미세한 마우스 조절로 스타일 풀리는 게 보이더라고요.
- 반응형에 사용되는 값들 추가 했습니다.
- nth-of-type을 사용할 때 min-width가 미디어 쿼리에 잡혀있지 않으면 제대로 적용되지 않아서 별도의 분기점을 추가했습니다.

###ChannelPage.jsx
- seLoading(false)의 위치로 인해 로딩이 제대로 적용되지 않는 버그가 있어서 호출 위치 변경했습니다.
- useEffect분리했습니다.

###Card.jsx
- 말줄임 시 밑에 잘린 글이 드러나는 부분 고쳤습니다.

###UserList.jsx
- 정렬을 위해 padding-right를 size값 기준으로 자동으로 정해지게 할려고 했으나 반응형애서 padding값을 유지 할 수 가 없어서 하드한 값으로 박았습니다. 계산법은 아래와 같으니 나중에 유지프로필의 사이즈 변경시 아래대로 계산하고 값만 가져와서 넣으면 됩니다.
- 계산법
padding-right: calc((100% - (${theme.userListValues.size} * 10)) / (${theme
    .userListValues.maxCount} - 1));
  );

###CheckedButtonList 컴포넌트 추가
- input:radio나 input:checkbox를 이용해 버튼처럼 이용 가능합니다.
- 
![image](https://user-images.githubusercontent.com/88189402/149619635-0875e87e-c857-430d-9236-1e59c73b1101.png)
- props 설명
 - list: 넘겨받을 데이터 리스트. value와 text로 구성
 - type: radio 또는 checkbox
 - primaryKey - 한 페이지 내에서 여러번 호출할 경우 정상적인 동작을 위해 key를 지정해줘야 한다.
 - onChange: 이벤트 리스너
 - useReverse: 반전 기능 사용 여부
 - reverseIndex: 반전 플래그를 몇 번째 input에 부여할건지. 기본이 0이고 첫번째에 적용된다. 마지막 버튼에 이 플래그를 적용하고 싶다면 list.length-1을 대입하면 된다.
 - unDefaultChecked: 기본 체크도 사용하고 싶지 않을경우
 - frameOnly: 기본 스타일을 해제하고 radio나 checkbox형태로 컴포넌트를 사용할 수 있다.

- 사용 예시
 
![image](https://user-images.githubusercontent.com/88189402/149619855-64aeadc3-dfea-4988-9bab-cf0436173919.png)
![image](https://user-images.githubusercontent.com/88189402/149619877-8c3a60be-21e4-4895-82b2-1f81f435c608.png)
![checkButtons](https://user-images.githubusercontent.com/88189402/149619901-9dfb051c-4e13-4c98-951e-ebc5d6a36916.gif)
- 차례대로 반전 사용 안함, 사용함, type:radio로 만들어진 버튼 리스트입니다.

###이렇게도 사용할 수 있어요.
![이런식으로도 활용할 수 있어요](https://user-images.githubusercontent.com/88189402/149619938-fbcb4176-39e4-4042-ab22-2861920560b6.gif)
<img width="189" alt="이런식2" src="https://user-images.githubusercontent.com/88189402/149619949-040604bd-ce67-4864-9399-8a1f18bb5005.png">
<img width="316" alt="이런식1" src="https://user-images.githubusercontent.com/88189402/149619952-8068d4ff-dddb-44a3-b062-c11c5bbf0a14.png">

## 📝 Results

> 구현한 결과를 첨부합니다.

## 📝 논의점

> 슬라이드 부분은 좀 더 정리가 필요할 것 같기도 합니다. 현재 배너와 카드에 대한 반응형을 밖에서 적용했는데 슬라이드 컴포넌트 안에서 할까 생각중입니다. 반응형 조작 중에 슬라이드 increase, decrease를 할 경우 생기는 버그가 있어서 수정예정입니다.
